### PR TITLE
Show secrets for both games (not just return secrets) and fix "all/no rings" buttons

### DIFF
--- a/ZoraGenGtk/ViewSecretsDialog.cs
+++ b/ZoraGenGtk/ViewSecretsDialog.cs
@@ -38,6 +38,14 @@ namespace Zyrenth.ZoraGen.GtkUI
 				throw new ArgumentNullException("info", "Game info cannot be null");
 			_info = info;
 			SetSecrets();
+
+			if (_info.Game == Game.Seasons) {
+				label3.Text = "Memories\n(for Seasons)";
+				label5.Text = "Secrets\n(for Ages)";
+			} else {
+				label3.Text = "Memories\n(for Ages)";
+				label5.Text = "Secrets\n(for Seasons)";
+			}
 		}
 		
 		private void SetSecrets()
@@ -47,6 +55,7 @@ namespace Zyrenth.ZoraGen.GtkUI
 			
 			if (_info.IsLinkedGame)
 			{
+				// Return secrets
 				bool returnSecret = true;
 				swMem1.SetSecret(new MemorySecret(_info, Memory.ClockShopKingZora, returnSecret));
 				swMem2.SetSecret(new MemorySecret(_info, Memory.GraveyardFairy, returnSecret));
@@ -58,6 +67,28 @@ namespace Zyrenth.ZoraGen.GtkUI
 				swMem8.SetSecret(new MemorySecret(_info, Memory.DekuTingle, returnSecret));
 				swMem9.SetSecret(new MemorySecret(_info, Memory.BiggoronElder, returnSecret));
 				swMem10.SetSecret(new MemorySecret(_info, Memory.RuulSymmetry, returnSecret));
+
+				// Other-game secrets
+				returnSecret = false;
+
+				// swap the game for this secret
+				GameInfo info2 = new GameInfo ();
+				info2.GameID = _info.GameID;
+				if (_info.Game == Game.Ages)
+					info2.Game = Game.Seasons;
+				else
+					info2.Game = Game.Ages;
+
+				swSec1.SetSecret (new MemorySecret (info2, Memory.ClockShopKingZora, returnSecret));
+				swSec2.SetSecret (new MemorySecret (info2, Memory.GraveyardFairy, returnSecret));
+				swSec3.SetSecret (new MemorySecret (info2, Memory.SubrosianTroy, returnSecret));
+				swSec4.SetSecret (new MemorySecret (info2, Memory.DiverPlen, returnSecret));
+				swSec5.SetSecret (new MemorySecret (info2, Memory.SmithLibrary, returnSecret));
+				swSec6.SetSecret (new MemorySecret (info2, Memory.PirateTokay, returnSecret));
+				swSec7.SetSecret (new MemorySecret (info2, Memory.TempleMamamu, returnSecret));
+				swSec8.SetSecret (new MemorySecret (info2, Memory.DekuTingle, returnSecret));
+				swSec9.SetSecret (new MemorySecret (info2, Memory.BiggoronElder, returnSecret));
+				swSec10.SetSecret (new MemorySecret (info2, Memory.RuulSymmetry, returnSecret));
 			}
 			
 			if (_info.Game == Game.Ages)

--- a/ZoraGenGtk/gtk-gui/Zyrenth.ZoraGen.GtkUI.MainWindow.cs
+++ b/ZoraGenGtk/gtk-gui/Zyrenth.ZoraGen.GtkUI.MainWindow.cs
@@ -5,350 +5,350 @@ namespace Zyrenth.ZoraGen.GtkUI
 	public partial class MainWindow
 	{
 		private global::Gtk.UIManager UIManager;
-		
+
 		private global::Gtk.Action FileAction;
-		
+
 		private global::Gtk.Action newAction;
-		
+
 		private global::Gtk.Action openAction;
-		
+
 		private global::Gtk.Action saveAction;
-		
+
 		private global::Gtk.Action saveAsAction;
-		
+
 		private global::Gtk.Action quitAction;
-		
+
 		private global::Gtk.Action SecretsAction;
-		
+
 		private global::Gtk.Action LoadGameSecretAction;
-		
+
 		private global::Gtk.Action LoadRingSecretAction;
-		
+
 		private global::Gtk.Action Action;
-		
+
 		private global::Gtk.Action GenerateSecretsAction;
-		
+
 		private global::Gtk.Action HelpAction;
-		
+
 		private global::Gtk.Action aboutAction;
-		
+
 		private global::Gtk.Action CheckForUpdatesAction;
-		
+
 		private global::Gtk.Action ImportBatteryAction;
-		
+
 		private global::Gtk.Action importBatteryAction;
-		
+
 		private global::Gtk.VBox vbox1;
-		
+
 		private global::Gtk.MenuBar menubar1;
-		
+
 		private global::Gtk.HBox hbox4;
-		
+
 		private global::Gtk.VBox vbox2;
-		
+
 		private global::Gtk.HBox hbox1;
-		
+
 		private global::Gtk.Frame frmGameType;
-		
+
 		private global::Gtk.Alignment GtkAlignment;
-		
+
 		private global::Gtk.Table table1;
-		
+
 		private global::Gtk.Image image1;
-		
+
 		private global::Gtk.Image image2;
-		
+
 		private global::Gtk.RadioButton rdoAges;
-		
+
 		private global::Gtk.RadioButton rdoSeasons;
-		
+
 		private global::Gtk.Label GtkLabel6;
-		
+
 		private global::Gtk.Frame frame2;
-		
+
 		private global::Gtk.Alignment GtkAlignment1;
-		
+
 		private global::Gtk.Table table2;
-		
+
 		private global::Gtk.CheckButton chkHeros;
-		
+
 		private global::Gtk.CheckButton chkLinked;
-		
+
 		private global::Gtk.Image image3;
-		
+
 		private global::Gtk.Label GtkLabel9;
-		
+
 		private global::Gtk.Table table3;
-		
+
 		private global::Gtk.ComboBox cmbAnimal;
-		
+
 		private global::Gtk.ComboBox cmbBehavior;
-		
+
 		private global::Gtk.Image imgAnimal;
-		
+
 		private global::Gtk.Label label2;
-		
+
 		private global::Gtk.Label label3;
-		
+
 		private global::Gtk.Label label4;
-		
+
 		private global::Gtk.Label label5;
-		
+
 		private global::Gtk.Label label6;
-		
+
 		private global::Gtk.SpinButton spinID;
-		
+
 		private global::Gtk.Entry txtChild;
-		
+
 		private global::Gtk.Entry txtHero;
-		
+
 		private global::Gtk.VBox vbox3;
-		
+
 		private global::Gtk.VBox vbox4;
-		
+
 		private global::Gtk.HBox hbox2;
-		
+
 		private global::Gtk.Button btnAllRings;
-		
+
 		private global::Gtk.Button btnNoRings;
-		
+
 		private global::Gtk.ScrolledWindow GtkScrolledWindow;
-		
+
 		private global::Gtk.NodeView nvRings;
-		
+
 		private global::Gtk.CheckButton chkFreeRingGiven;
 
-		protected virtual void Build ()
+		protected virtual void Build()
 		{
-			global::Stetic.Gui.Initialize (this);
+			global::Stetic.Gui.Initialize(this);
 			// Widget Zyrenth.ZoraGen.GtkUI.MainWindow
-			this.UIManager = new global::Gtk.UIManager ();
-			global::Gtk.ActionGroup w1 = new global::Gtk.ActionGroup ("Default");
-			this.FileAction = new global::Gtk.Action ("FileAction", global::Mono.Unix.Catalog.GetString ("File"), null, null);
-			this.FileAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("File");
-			w1.Add (this.FileAction, null);
-			this.newAction = new global::Gtk.Action ("newAction", global::Mono.Unix.Catalog.GetString ("_New"), null, "gtk-new");
-			this.newAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("New");
-			w1.Add (this.newAction, null);
-			this.openAction = new global::Gtk.Action ("openAction", global::Mono.Unix.Catalog.GetString ("_Open"), null, "gtk-open");
-			this.openAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Open");
-			w1.Add (this.openAction, null);
-			this.saveAction = new global::Gtk.Action ("saveAction", global::Mono.Unix.Catalog.GetString ("_Save"), null, "gtk-save");
-			this.saveAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Save");
-			w1.Add (this.saveAction, null);
-			this.saveAsAction = new global::Gtk.Action ("saveAsAction", global::Mono.Unix.Catalog.GetString ("Save As"), null, "gtk-save-as");
-			this.saveAsAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Save As");
-			w1.Add (this.saveAsAction, null);
-			this.quitAction = new global::Gtk.Action ("quitAction", global::Mono.Unix.Catalog.GetString ("_Quit"), null, "gtk-quit");
-			this.quitAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Quit");
-			w1.Add (this.quitAction, null);
-			this.SecretsAction = new global::Gtk.Action ("SecretsAction", global::Mono.Unix.Catalog.GetString ("Secrets"), null, null);
-			this.SecretsAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Secrets");
-			w1.Add (this.SecretsAction, null);
-			this.LoadGameSecretAction = new global::Gtk.Action ("LoadGameSecretAction", global::Mono.Unix.Catalog.GetString ("Load Game Secret"), null, null);
-			this.LoadGameSecretAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Load Game Secret");
-			w1.Add (this.LoadGameSecretAction, null);
-			this.LoadRingSecretAction = new global::Gtk.Action ("LoadRingSecretAction", global::Mono.Unix.Catalog.GetString ("Load Ring Secret"), null, null);
-			this.LoadRingSecretAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Load Ring Secret");
-			w1.Add (this.LoadRingSecretAction, null);
-			this.Action = new global::Gtk.Action ("Action", global::Mono.Unix.Catalog.GetString ("---"), null, null);
-			this.Action.ShortLabel = global::Mono.Unix.Catalog.GetString ("---");
-			w1.Add (this.Action, null);
-			this.GenerateSecretsAction = new global::Gtk.Action ("GenerateSecretsAction", global::Mono.Unix.Catalog.GetString ("Generate Secrets"), null, null);
-			this.GenerateSecretsAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Generate Secrets");
-			w1.Add (this.GenerateSecretsAction, null);
-			this.HelpAction = new global::Gtk.Action ("HelpAction", global::Mono.Unix.Catalog.GetString ("Help"), null, null);
-			this.HelpAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Help");
-			w1.Add (this.HelpAction, null);
-			this.aboutAction = new global::Gtk.Action ("aboutAction", global::Mono.Unix.Catalog.GetString ("About"), null, "gtk-about");
-			this.aboutAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("About");
-			w1.Add (this.aboutAction, null);
-			this.CheckForUpdatesAction = new global::Gtk.Action ("CheckForUpdatesAction", global::Mono.Unix.Catalog.GetString ("Check for Updates"), null, null);
-			this.CheckForUpdatesAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Check for Updates");
-			w1.Add (this.CheckForUpdatesAction, null);
-			this.ImportBatteryAction = new global::Gtk.Action ("ImportBatteryAction", global::Mono.Unix.Catalog.GetString ("Import Battery"), null, null);
-			this.ImportBatteryAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Import Battery");
-			w1.Add (this.ImportBatteryAction, null);
-			this.importBatteryAction = new global::Gtk.Action ("importBatteryAction", global::Mono.Unix.Catalog.GetString ("Import Battery"), global::Mono.Unix.Catalog.GetString ("Imports a VBA battery file"), null);
-			this.importBatteryAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Import Battery");
-			w1.Add (this.importBatteryAction, null);
-			this.UIManager.InsertActionGroup (w1, 0);
-			this.AddAccelGroup (this.UIManager.AccelGroup);
+			this.UIManager = new global::Gtk.UIManager();
+			global::Gtk.ActionGroup w1 = new global::Gtk.ActionGroup("Default");
+			this.FileAction = new global::Gtk.Action("FileAction", global::Mono.Unix.Catalog.GetString("File"), null, null);
+			this.FileAction.ShortLabel = global::Mono.Unix.Catalog.GetString("File");
+			w1.Add(this.FileAction, null);
+			this.newAction = new global::Gtk.Action("newAction", global::Mono.Unix.Catalog.GetString("_New"), null, "gtk-new");
+			this.newAction.ShortLabel = global::Mono.Unix.Catalog.GetString("New");
+			w1.Add(this.newAction, null);
+			this.openAction = new global::Gtk.Action("openAction", global::Mono.Unix.Catalog.GetString("_Open"), null, "gtk-open");
+			this.openAction.ShortLabel = global::Mono.Unix.Catalog.GetString("Open");
+			w1.Add(this.openAction, null);
+			this.saveAction = new global::Gtk.Action("saveAction", global::Mono.Unix.Catalog.GetString("_Save"), null, "gtk-save");
+			this.saveAction.ShortLabel = global::Mono.Unix.Catalog.GetString("Save");
+			w1.Add(this.saveAction, null);
+			this.saveAsAction = new global::Gtk.Action("saveAsAction", global::Mono.Unix.Catalog.GetString("Save As"), null, "gtk-save-as");
+			this.saveAsAction.ShortLabel = global::Mono.Unix.Catalog.GetString("Save As");
+			w1.Add(this.saveAsAction, null);
+			this.quitAction = new global::Gtk.Action("quitAction", global::Mono.Unix.Catalog.GetString("_Quit"), null, "gtk-quit");
+			this.quitAction.ShortLabel = global::Mono.Unix.Catalog.GetString("Quit");
+			w1.Add(this.quitAction, null);
+			this.SecretsAction = new global::Gtk.Action("SecretsAction", global::Mono.Unix.Catalog.GetString("Secrets"), null, null);
+			this.SecretsAction.ShortLabel = global::Mono.Unix.Catalog.GetString("Secrets");
+			w1.Add(this.SecretsAction, null);
+			this.LoadGameSecretAction = new global::Gtk.Action("LoadGameSecretAction", global::Mono.Unix.Catalog.GetString("Load Game Secret"), null, null);
+			this.LoadGameSecretAction.ShortLabel = global::Mono.Unix.Catalog.GetString("Load Game Secret");
+			w1.Add(this.LoadGameSecretAction, null);
+			this.LoadRingSecretAction = new global::Gtk.Action("LoadRingSecretAction", global::Mono.Unix.Catalog.GetString("Load Ring Secret"), null, null);
+			this.LoadRingSecretAction.ShortLabel = global::Mono.Unix.Catalog.GetString("Load Ring Secret");
+			w1.Add(this.LoadRingSecretAction, null);
+			this.Action = new global::Gtk.Action("Action", global::Mono.Unix.Catalog.GetString("---"), null, null);
+			this.Action.ShortLabel = global::Mono.Unix.Catalog.GetString("---");
+			w1.Add(this.Action, null);
+			this.GenerateSecretsAction = new global::Gtk.Action("GenerateSecretsAction", global::Mono.Unix.Catalog.GetString("Generate Secrets"), null, null);
+			this.GenerateSecretsAction.ShortLabel = global::Mono.Unix.Catalog.GetString("Generate Secrets");
+			w1.Add(this.GenerateSecretsAction, null);
+			this.HelpAction = new global::Gtk.Action("HelpAction", global::Mono.Unix.Catalog.GetString("Help"), null, null);
+			this.HelpAction.ShortLabel = global::Mono.Unix.Catalog.GetString("Help");
+			w1.Add(this.HelpAction, null);
+			this.aboutAction = new global::Gtk.Action("aboutAction", global::Mono.Unix.Catalog.GetString("About"), null, "gtk-about");
+			this.aboutAction.ShortLabel = global::Mono.Unix.Catalog.GetString("About");
+			w1.Add(this.aboutAction, null);
+			this.CheckForUpdatesAction = new global::Gtk.Action("CheckForUpdatesAction", global::Mono.Unix.Catalog.GetString("Check for Updates"), null, null);
+			this.CheckForUpdatesAction.ShortLabel = global::Mono.Unix.Catalog.GetString("Check for Updates");
+			w1.Add(this.CheckForUpdatesAction, null);
+			this.ImportBatteryAction = new global::Gtk.Action("ImportBatteryAction", global::Mono.Unix.Catalog.GetString("Import Battery"), null, null);
+			this.ImportBatteryAction.ShortLabel = global::Mono.Unix.Catalog.GetString("Import Battery");
+			w1.Add(this.ImportBatteryAction, null);
+			this.importBatteryAction = new global::Gtk.Action("importBatteryAction", global::Mono.Unix.Catalog.GetString("Import Battery"), global::Mono.Unix.Catalog.GetString("Imports a VBA battery file"), null);
+			this.importBatteryAction.ShortLabel = global::Mono.Unix.Catalog.GetString("Import Battery");
+			w1.Add(this.importBatteryAction, null);
+			this.UIManager.InsertActionGroup(w1, 0);
+			this.AddAccelGroup(this.UIManager.AccelGroup);
 			this.Name = "Zyrenth.ZoraGen.GtkUI.MainWindow";
-			this.Title = global::Mono.Unix.Catalog.GetString ("ZoraGen - Zelda Oracles Password Generator");
-			this.Icon = global::Gdk.Pixbuf.LoadFromResource ("Zyrenth.ZoraGen.GtkUI.Farore.ico");
+			this.Title = global::Mono.Unix.Catalog.GetString("ZoraGen - Zelda Oracles Password Generator");
+			this.Icon = global::Gdk.Pixbuf.LoadFromResource("Zyrenth.ZoraGen.GtkUI.Farore.ico");
 			this.WindowPosition = ((global::Gtk.WindowPosition)(4));
 			this.Resizable = false;
 			// Container child Zyrenth.ZoraGen.GtkUI.MainWindow.Gtk.Container+ContainerChild
-			this.vbox1 = new global::Gtk.VBox ();
+			this.vbox1 = new global::Gtk.VBox();
 			this.vbox1.Name = "vbox1";
 			// Container child vbox1.Gtk.Box+BoxChild
-			this.UIManager.AddUiFromString ("<ui><menubar name='menubar1'><menu name='FileAction' action='FileAction'><menuitem name='newAction' action='newAction'/><menuitem name='openAction' action='openAction'/><menuitem name='saveAction' action='saveAction'/><menuitem name='saveAsAction' action='saveAsAction'/><separator/><menuitem name='importBatteryAction' action='importBatteryAction'/><separator/><menuitem name='quitAction' action='quitAction'/></menu><menu name='SecretsAction' action='SecretsAction'><menuitem name='LoadGameSecretAction' action='LoadGameSecretAction'/><menuitem name='LoadRingSecretAction' action='LoadRingSecretAction'/><separator/><menuitem name='GenerateSecretsAction' action='GenerateSecretsAction'/></menu><menu name='HelpAction' action='HelpAction'><menuitem name='aboutAction' action='aboutAction'/><menuitem name='CheckForUpdatesAction' action='CheckForUpdatesAction'/></menu></menubar></ui>");
-			this.menubar1 = ((global::Gtk.MenuBar)(this.UIManager.GetWidget ("/menubar1")));
+			this.UIManager.AddUiFromString("<ui><menubar name='menubar1'><menu name='FileAction' action='FileAction'><menuitem name='newAction' action='newAction'/><menuitem name='openAction' action='openAction'/><menuitem name='saveAction' action='saveAction'/><menuitem name='saveAsAction' action='saveAsAction'/><separator/><menuitem name='importBatteryAction' action='importBatteryAction'/><separator/><menuitem name='quitAction' action='quitAction'/></menu><menu name='SecretsAction' action='SecretsAction'><menuitem name='LoadGameSecretAction' action='LoadGameSecretAction'/><menuitem name='LoadRingSecretAction' action='LoadRingSecretAction'/><separator/><menuitem name='GenerateSecretsAction' action='GenerateSecretsAction'/></menu><menu name='HelpAction' action='HelpAction'><menuitem name='aboutAction' action='aboutAction'/><menuitem name='CheckForUpdatesAction' action='CheckForUpdatesAction'/></menu></menubar></ui>");
+			this.menubar1 = ((global::Gtk.MenuBar)(this.UIManager.GetWidget("/menubar1")));
 			this.menubar1.Name = "menubar1";
-			this.vbox1.Add (this.menubar1);
-			global::Gtk.Box.BoxChild w2 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.menubar1]));
+			this.vbox1.Add(this.menubar1);
+			global::Gtk.Box.BoxChild w2 = ((global::Gtk.Box.BoxChild)(this.vbox1[this.menubar1]));
 			w2.Position = 0;
 			w2.Expand = false;
 			w2.Fill = false;
 			// Container child vbox1.Gtk.Box+BoxChild
-			this.hbox4 = new global::Gtk.HBox ();
+			this.hbox4 = new global::Gtk.HBox();
 			this.hbox4.Name = "hbox4";
 			this.hbox4.Spacing = 6;
 			this.hbox4.BorderWidth = ((uint)(10));
 			// Container child hbox4.Gtk.Box+BoxChild
-			this.vbox2 = new global::Gtk.VBox ();
+			this.vbox2 = new global::Gtk.VBox();
 			this.vbox2.Name = "vbox2";
 			this.vbox2.Spacing = 6;
 			// Container child vbox2.Gtk.Box+BoxChild
-			this.hbox1 = new global::Gtk.HBox ();
+			this.hbox1 = new global::Gtk.HBox();
 			this.hbox1.Name = "hbox1";
 			this.hbox1.Spacing = 6;
 			// Container child hbox1.Gtk.Box+BoxChild
-			this.frmGameType = new global::Gtk.Frame ();
+			this.frmGameType = new global::Gtk.Frame();
 			this.frmGameType.WidthRequest = 0;
 			this.frmGameType.HeightRequest = 0;
 			this.frmGameType.Name = "frmGameType";
 			// Container child frmGameType.Gtk.Container+ContainerChild
-			this.GtkAlignment = new global::Gtk.Alignment (0F, 0F, 1F, 1F);
+			this.GtkAlignment = new global::Gtk.Alignment(0F, 0F, 1F, 1F);
 			this.GtkAlignment.Name = "GtkAlignment";
 			// Container child GtkAlignment.Gtk.Container+ContainerChild
-			this.table1 = new global::Gtk.Table (((uint)(2)), ((uint)(2)), false);
+			this.table1 = new global::Gtk.Table(((uint)(2)), ((uint)(2)), false);
 			this.table1.Name = "table1";
 			this.table1.BorderWidth = ((uint)(3));
 			// Container child table1.Gtk.Table+TableChild
-			this.image1 = new global::Gtk.Image ();
+			this.image1 = new global::Gtk.Image();
 			this.image1.Name = "image1";
-			this.image1.Pixbuf = global::Gdk.Pixbuf.LoadFromResource ("Zyrenth.ZoraGen.GtkUI.Images.Characters.Nayru.gif");
-			this.table1.Add (this.image1);
-			global::Gtk.Table.TableChild w3 = ((global::Gtk.Table.TableChild)(this.table1 [this.image1]));
+			this.image1.Pixbuf = global::Gdk.Pixbuf.LoadFromResource("Zyrenth.ZoraGen.GtkUI.Images.Characters.Nayru.gif");
+			this.table1.Add(this.image1);
+			global::Gtk.Table.TableChild w3 = ((global::Gtk.Table.TableChild)(this.table1[this.image1]));
 			w3.XOptions = ((global::Gtk.AttachOptions)(4));
 			w3.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
-			this.image2 = new global::Gtk.Image ();
+			this.image2 = new global::Gtk.Image();
 			this.image2.Name = "image2";
-			this.image2.Pixbuf = global::Gdk.Pixbuf.LoadFromResource ("Zyrenth.ZoraGen.GtkUI.Images.Characters.Din.gif");
-			this.table1.Add (this.image2);
-			global::Gtk.Table.TableChild w4 = ((global::Gtk.Table.TableChild)(this.table1 [this.image2]));
+			this.image2.Pixbuf = global::Gdk.Pixbuf.LoadFromResource("Zyrenth.ZoraGen.GtkUI.Images.Characters.Din.gif");
+			this.table1.Add(this.image2);
+			global::Gtk.Table.TableChild w4 = ((global::Gtk.Table.TableChild)(this.table1[this.image2]));
 			w4.TopAttach = ((uint)(1));
 			w4.BottomAttach = ((uint)(2));
 			w4.XOptions = ((global::Gtk.AttachOptions)(4));
 			w4.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
-			this.rdoAges = new global::Gtk.RadioButton (global::Mono.Unix.Catalog.GetString ("Ages"));
+			this.rdoAges = new global::Gtk.RadioButton(global::Mono.Unix.Catalog.GetString("Ages"));
 			this.rdoAges.CanFocus = true;
 			this.rdoAges.Name = "rdoAges";
 			this.rdoAges.DrawIndicator = true;
 			this.rdoAges.UseUnderline = true;
-			this.rdoAges.Group = new global::GLib.SList (global::System.IntPtr.Zero);
-			this.table1.Add (this.rdoAges);
-			global::Gtk.Table.TableChild w5 = ((global::Gtk.Table.TableChild)(this.table1 [this.rdoAges]));
+			this.rdoAges.Group = new global::GLib.SList(global::System.IntPtr.Zero);
+			this.table1.Add(this.rdoAges);
+			global::Gtk.Table.TableChild w5 = ((global::Gtk.Table.TableChild)(this.table1[this.rdoAges]));
 			w5.LeftAttach = ((uint)(1));
 			w5.RightAttach = ((uint)(2));
 			w5.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
-			this.rdoSeasons = new global::Gtk.RadioButton (global::Mono.Unix.Catalog.GetString ("Seasons"));
+			this.rdoSeasons = new global::Gtk.RadioButton(global::Mono.Unix.Catalog.GetString("Seasons"));
 			this.rdoSeasons.CanFocus = true;
 			this.rdoSeasons.Name = "rdoSeasons";
 			this.rdoSeasons.DrawIndicator = true;
 			this.rdoSeasons.UseUnderline = true;
 			this.rdoSeasons.Group = this.rdoAges.Group;
-			this.table1.Add (this.rdoSeasons);
-			global::Gtk.Table.TableChild w6 = ((global::Gtk.Table.TableChild)(this.table1 [this.rdoSeasons]));
+			this.table1.Add(this.rdoSeasons);
+			global::Gtk.Table.TableChild w6 = ((global::Gtk.Table.TableChild)(this.table1[this.rdoSeasons]));
 			w6.TopAttach = ((uint)(1));
 			w6.BottomAttach = ((uint)(2));
 			w6.LeftAttach = ((uint)(1));
 			w6.RightAttach = ((uint)(2));
 			w6.YOptions = ((global::Gtk.AttachOptions)(4));
-			this.GtkAlignment.Add (this.table1);
-			this.frmGameType.Add (this.GtkAlignment);
-			this.GtkLabel6 = new global::Gtk.Label ();
+			this.GtkAlignment.Add(this.table1);
+			this.frmGameType.Add(this.GtkAlignment);
+			this.GtkLabel6 = new global::Gtk.Label();
 			this.GtkLabel6.Name = "GtkLabel6";
-			this.GtkLabel6.LabelProp = global::Mono.Unix.Catalog.GetString ("Secret For...");
+			this.GtkLabel6.LabelProp = global::Mono.Unix.Catalog.GetString("Secret For...");
 			this.GtkLabel6.UseMarkup = true;
 			this.frmGameType.LabelWidget = this.GtkLabel6;
-			this.hbox1.Add (this.frmGameType);
-			global::Gtk.Box.BoxChild w9 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this.frmGameType]));
+			this.hbox1.Add(this.frmGameType);
+			global::Gtk.Box.BoxChild w9 = ((global::Gtk.Box.BoxChild)(this.hbox1[this.frmGameType]));
 			w9.Position = 0;
 			w9.Expand = false;
 			w9.Fill = false;
 			// Container child hbox1.Gtk.Box+BoxChild
-			this.frame2 = new global::Gtk.Frame ();
+			this.frame2 = new global::Gtk.Frame();
 			this.frame2.Name = "frame2";
 			// Container child frame2.Gtk.Container+ContainerChild
-			this.GtkAlignment1 = new global::Gtk.Alignment (0F, 0F, 1F, 1F);
+			this.GtkAlignment1 = new global::Gtk.Alignment(0F, 0F, 1F, 1F);
 			this.GtkAlignment1.Name = "GtkAlignment1";
 			// Container child GtkAlignment1.Gtk.Container+ContainerChild
-			this.table2 = new global::Gtk.Table (((uint)(2)), ((uint)(2)), false);
+			this.table2 = new global::Gtk.Table(((uint)(2)), ((uint)(2)), false);
 			this.table2.Name = "table2";
 			this.table2.BorderWidth = ((uint)(3));
 			// Container child table2.Gtk.Table+TableChild
-			this.chkHeros = new global::Gtk.CheckButton ();
+			this.chkHeros = new global::Gtk.CheckButton();
 			this.chkHeros.CanFocus = true;
 			this.chkHeros.Name = "chkHeros";
-			this.chkHeros.Label = global::Mono.Unix.Catalog.GetString ("Hero's Quest");
+			this.chkHeros.Label = global::Mono.Unix.Catalog.GetString("Hero's Quest");
 			this.chkHeros.DrawIndicator = true;
 			this.chkHeros.UseUnderline = true;
-			this.table2.Add (this.chkHeros);
-			global::Gtk.Table.TableChild w10 = ((global::Gtk.Table.TableChild)(this.table2 [this.chkHeros]));
+			this.table2.Add(this.chkHeros);
+			global::Gtk.Table.TableChild w10 = ((global::Gtk.Table.TableChild)(this.table2[this.chkHeros]));
 			w10.TopAttach = ((uint)(1));
 			w10.BottomAttach = ((uint)(2));
 			w10.LeftAttach = ((uint)(1));
 			w10.RightAttach = ((uint)(2));
 			w10.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table2.Gtk.Table+TableChild
-			this.chkLinked = new global::Gtk.CheckButton ();
+			this.chkLinked = new global::Gtk.CheckButton();
 			this.chkLinked.CanFocus = true;
 			this.chkLinked.Name = "chkLinked";
-			this.chkLinked.Label = global::Mono.Unix.Catalog.GetString ("Linked Game");
+			this.chkLinked.Label = global::Mono.Unix.Catalog.GetString("Linked Game");
 			this.chkLinked.DrawIndicator = true;
 			this.chkLinked.UseUnderline = true;
-			this.table2.Add (this.chkLinked);
-			global::Gtk.Table.TableChild w11 = ((global::Gtk.Table.TableChild)(this.table2 [this.chkLinked]));
+			this.table2.Add(this.chkLinked);
+			global::Gtk.Table.TableChild w11 = ((global::Gtk.Table.TableChild)(this.table2[this.chkLinked]));
 			w11.LeftAttach = ((uint)(1));
 			w11.RightAttach = ((uint)(2));
 			w11.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table2.Gtk.Table+TableChild
-			this.image3 = new global::Gtk.Image ();
+			this.image3 = new global::Gtk.Image();
 			this.image3.Name = "image3";
-			this.image3.Pixbuf = global::Gdk.Pixbuf.LoadFromResource ("Zyrenth.ZoraGen.GtkUI.Images.Triforce.png");
-			this.table2.Add (this.image3);
-			global::Gtk.Table.TableChild w12 = ((global::Gtk.Table.TableChild)(this.table2 [this.image3]));
+			this.image3.Pixbuf = global::Gdk.Pixbuf.LoadFromResource("Zyrenth.ZoraGen.GtkUI.Images.Triforce.png");
+			this.table2.Add(this.image3);
+			global::Gtk.Table.TableChild w12 = ((global::Gtk.Table.TableChild)(this.table2[this.image3]));
 			w12.TopAttach = ((uint)(1));
 			w12.BottomAttach = ((uint)(2));
 			w12.XOptions = ((global::Gtk.AttachOptions)(4));
 			w12.YOptions = ((global::Gtk.AttachOptions)(4));
-			this.GtkAlignment1.Add (this.table2);
-			this.frame2.Add (this.GtkAlignment1);
-			this.GtkLabel9 = new global::Gtk.Label ();
+			this.GtkAlignment1.Add(this.table2);
+			this.frame2.Add(this.GtkAlignment1);
+			this.GtkLabel9 = new global::Gtk.Label();
 			this.GtkLabel9.Name = "GtkLabel9";
-			this.GtkLabel9.LabelProp = global::Mono.Unix.Catalog.GetString ("Game Type");
+			this.GtkLabel9.LabelProp = global::Mono.Unix.Catalog.GetString("Game Type");
 			this.GtkLabel9.UseMarkup = true;
 			this.frame2.LabelWidget = this.GtkLabel9;
-			this.hbox1.Add (this.frame2);
-			global::Gtk.Box.BoxChild w15 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this.frame2]));
+			this.hbox1.Add(this.frame2);
+			global::Gtk.Box.BoxChild w15 = ((global::Gtk.Box.BoxChild)(this.hbox1[this.frame2]));
 			w15.Position = 1;
 			w15.Expand = false;
 			w15.Fill = false;
-			this.vbox2.Add (this.hbox1);
-			global::Gtk.Box.BoxChild w16 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.hbox1]));
+			this.vbox2.Add(this.hbox1);
+			global::Gtk.Box.BoxChild w16 = ((global::Gtk.Box.BoxChild)(this.vbox2[this.hbox1]));
 			w16.Position = 0;
 			w16.Expand = false;
 			w16.Fill = false;
 			// Container child vbox2.Gtk.Box+BoxChild
-			this.table3 = new global::Gtk.Table (((uint)(3)), ((uint)(4)), false);
+			this.table3 = new global::Gtk.Table(((uint)(3)), ((uint)(4)), false);
 			this.table3.Name = "table3";
 			this.table3.RowSpacing = ((uint)(6));
 			this.table3.ColumnSpacing = ((uint)(6));
 			// Container child table3.Gtk.Table+TableChild
-			this.cmbAnimal = global::Gtk.ComboBox.NewText ();
-			this.cmbAnimal.AppendText (global::Mono.Unix.Catalog.GetString ("Ricky"));
-			this.cmbAnimal.AppendText (global::Mono.Unix.Catalog.GetString ("Dimitri"));
-			this.cmbAnimal.AppendText (global::Mono.Unix.Catalog.GetString ("Moosh"));
+			this.cmbAnimal = global::Gtk.ComboBox.NewText();
+			this.cmbAnimal.AppendText(global::Mono.Unix.Catalog.GetString("Ricky"));
+			this.cmbAnimal.AppendText(global::Mono.Unix.Catalog.GetString("Dimitri"));
+			this.cmbAnimal.AppendText(global::Mono.Unix.Catalog.GetString("Moosh"));
 			this.cmbAnimal.Name = "cmbAnimal";
 			this.cmbAnimal.Active = 0;
-			this.table3.Add (this.cmbAnimal);
-			global::Gtk.Table.TableChild w17 = ((global::Gtk.Table.TableChild)(this.table3 [this.cmbAnimal]));
+			this.table3.Add(this.cmbAnimal);
+			global::Gtk.Table.TableChild w17 = ((global::Gtk.Table.TableChild)(this.table3[this.cmbAnimal]));
 			w17.TopAttach = ((uint)(2));
 			w17.BottomAttach = ((uint)(3));
 			w17.LeftAttach = ((uint)(1));
@@ -356,10 +356,10 @@ namespace Zyrenth.ZoraGen.GtkUI
 			w17.XOptions = ((global::Gtk.AttachOptions)(4));
 			w17.YOptions = ((global::Gtk.AttachOptions)(0));
 			// Container child table3.Gtk.Table+TableChild
-			this.cmbBehavior = global::Gtk.ComboBox.NewText ();
+			this.cmbBehavior = global::Gtk.ComboBox.NewText();
 			this.cmbBehavior.Name = "cmbBehavior";
-			this.table3.Add (this.cmbBehavior);
-			global::Gtk.Table.TableChild w18 = ((global::Gtk.Table.TableChild)(this.table3 [this.cmbBehavior]));
+			this.table3.Add(this.cmbBehavior);
+			global::Gtk.Table.TableChild w18 = ((global::Gtk.Table.TableChild)(this.table3[this.cmbBehavior]));
 			w18.TopAttach = ((uint)(1));
 			w18.BottomAttach = ((uint)(2));
 			w18.LeftAttach = ((uint)(3));
@@ -367,10 +367,10 @@ namespace Zyrenth.ZoraGen.GtkUI
 			w18.XOptions = ((global::Gtk.AttachOptions)(4));
 			w18.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
-			this.imgAnimal = new global::Gtk.Image ();
+			this.imgAnimal = new global::Gtk.Image();
 			this.imgAnimal.Name = "imgAnimal";
-			this.table3.Add (this.imgAnimal);
-			global::Gtk.Table.TableChild w19 = ((global::Gtk.Table.TableChild)(this.table3 [this.imgAnimal]));
+			this.table3.Add(this.imgAnimal);
+			global::Gtk.Table.TableChild w19 = ((global::Gtk.Table.TableChild)(this.table3[this.imgAnimal]));
 			w19.TopAttach = ((uint)(2));
 			w19.BottomAttach = ((uint)(3));
 			w19.LeftAttach = ((uint)(2));
@@ -378,43 +378,43 @@ namespace Zyrenth.ZoraGen.GtkUI
 			w19.XOptions = ((global::Gtk.AttachOptions)(4));
 			w19.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
-			this.label2 = new global::Gtk.Label ();
+			this.label2 = new global::Gtk.Label();
 			this.label2.Name = "label2";
 			this.label2.Xalign = 0F;
-			this.label2.LabelProp = global::Mono.Unix.Catalog.GetString ("ID");
-			this.table3.Add (this.label2);
-			global::Gtk.Table.TableChild w20 = ((global::Gtk.Table.TableChild)(this.table3 [this.label2]));
+			this.label2.LabelProp = global::Mono.Unix.Catalog.GetString("ID");
+			this.table3.Add(this.label2);
+			global::Gtk.Table.TableChild w20 = ((global::Gtk.Table.TableChild)(this.table3[this.label2]));
 			w20.TopAttach = ((uint)(1));
 			w20.BottomAttach = ((uint)(2));
 			w20.XOptions = ((global::Gtk.AttachOptions)(4));
 			w20.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
-			this.label3 = new global::Gtk.Label ();
+			this.label3 = new global::Gtk.Label();
 			this.label3.Name = "label3";
 			this.label3.Xalign = 0F;
-			this.label3.LabelProp = global::Mono.Unix.Catalog.GetString ("Hero");
-			this.table3.Add (this.label3);
-			global::Gtk.Table.TableChild w21 = ((global::Gtk.Table.TableChild)(this.table3 [this.label3]));
+			this.label3.LabelProp = global::Mono.Unix.Catalog.GetString("Hero");
+			this.table3.Add(this.label3);
+			global::Gtk.Table.TableChild w21 = ((global::Gtk.Table.TableChild)(this.table3[this.label3]));
 			w21.XOptions = ((global::Gtk.AttachOptions)(4));
 			w21.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
-			this.label4 = new global::Gtk.Label ();
+			this.label4 = new global::Gtk.Label();
 			this.label4.Name = "label4";
 			this.label4.Xalign = 0F;
-			this.label4.LabelProp = global::Mono.Unix.Catalog.GetString ("Child");
-			this.table3.Add (this.label4);
-			global::Gtk.Table.TableChild w22 = ((global::Gtk.Table.TableChild)(this.table3 [this.label4]));
+			this.label4.LabelProp = global::Mono.Unix.Catalog.GetString("Child");
+			this.table3.Add(this.label4);
+			global::Gtk.Table.TableChild w22 = ((global::Gtk.Table.TableChild)(this.table3[this.label4]));
 			w22.LeftAttach = ((uint)(2));
 			w22.RightAttach = ((uint)(3));
 			w22.XOptions = ((global::Gtk.AttachOptions)(4));
 			w22.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
-			this.label5 = new global::Gtk.Label ();
+			this.label5 = new global::Gtk.Label();
 			this.label5.Name = "label5";
 			this.label5.Xalign = 0F;
-			this.label5.LabelProp = global::Mono.Unix.Catalog.GetString ("Behavior");
-			this.table3.Add (this.label5);
-			global::Gtk.Table.TableChild w23 = ((global::Gtk.Table.TableChild)(this.table3 [this.label5]));
+			this.label5.LabelProp = global::Mono.Unix.Catalog.GetString("Behavior");
+			this.table3.Add(this.label5);
+			global::Gtk.Table.TableChild w23 = ((global::Gtk.Table.TableChild)(this.table3[this.label5]));
 			w23.TopAttach = ((uint)(1));
 			w23.BottomAttach = ((uint)(2));
 			w23.LeftAttach = ((uint)(2));
@@ -422,25 +422,25 @@ namespace Zyrenth.ZoraGen.GtkUI
 			w23.XOptions = ((global::Gtk.AttachOptions)(4));
 			w23.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
-			this.label6 = new global::Gtk.Label ();
+			this.label6 = new global::Gtk.Label();
 			this.label6.Name = "label6";
 			this.label6.Xalign = 0F;
-			this.label6.LabelProp = global::Mono.Unix.Catalog.GetString ("Animal");
-			this.table3.Add (this.label6);
-			global::Gtk.Table.TableChild w24 = ((global::Gtk.Table.TableChild)(this.table3 [this.label6]));
+			this.label6.LabelProp = global::Mono.Unix.Catalog.GetString("Animal");
+			this.table3.Add(this.label6);
+			global::Gtk.Table.TableChild w24 = ((global::Gtk.Table.TableChild)(this.table3[this.label6]));
 			w24.TopAttach = ((uint)(2));
 			w24.BottomAttach = ((uint)(3));
 			w24.XOptions = ((global::Gtk.AttachOptions)(4));
 			w24.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
-			this.spinID = new global::Gtk.SpinButton (0, 32767, 1);
+			this.spinID = new global::Gtk.SpinButton(0, 32767, 1);
 			this.spinID.CanFocus = true;
 			this.spinID.Name = "spinID";
 			this.spinID.Adjustment.PageIncrement = 10;
 			this.spinID.ClimbRate = 1;
 			this.spinID.Numeric = true;
-			this.table3.Add (this.spinID);
-			global::Gtk.Table.TableChild w25 = ((global::Gtk.Table.TableChild)(this.table3 [this.spinID]));
+			this.table3.Add(this.spinID);
+			global::Gtk.Table.TableChild w25 = ((global::Gtk.Table.TableChild)(this.table3[this.spinID]));
 			w25.TopAttach = ((uint)(1));
 			w25.BottomAttach = ((uint)(2));
 			w25.LeftAttach = ((uint)(1));
@@ -448,138 +448,141 @@ namespace Zyrenth.ZoraGen.GtkUI
 			w25.XOptions = ((global::Gtk.AttachOptions)(4));
 			w25.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
-			this.txtChild = new global::Gtk.Entry ();
+			this.txtChild = new global::Gtk.Entry();
 			this.txtChild.WidthRequest = 70;
 			this.txtChild.CanFocus = true;
 			this.txtChild.Name = "txtChild";
 			this.txtChild.IsEditable = true;
 			this.txtChild.MaxLength = 5;
 			this.txtChild.InvisibleChar = '●';
-			this.table3.Add (this.txtChild);
-			global::Gtk.Table.TableChild w26 = ((global::Gtk.Table.TableChild)(this.table3 [this.txtChild]));
+			this.table3.Add(this.txtChild);
+			global::Gtk.Table.TableChild w26 = ((global::Gtk.Table.TableChild)(this.table3[this.txtChild]));
 			w26.LeftAttach = ((uint)(3));
 			w26.RightAttach = ((uint)(4));
 			w26.XOptions = ((global::Gtk.AttachOptions)(4));
 			w26.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
-			this.txtHero = new global::Gtk.Entry ();
+			this.txtHero = new global::Gtk.Entry();
 			this.txtHero.WidthRequest = 70;
 			this.txtHero.CanFocus = true;
 			this.txtHero.Name = "txtHero";
 			this.txtHero.IsEditable = true;
 			this.txtHero.MaxLength = 5;
 			this.txtHero.InvisibleChar = '●';
-			this.table3.Add (this.txtHero);
-			global::Gtk.Table.TableChild w27 = ((global::Gtk.Table.TableChild)(this.table3 [this.txtHero]));
+			this.table3.Add(this.txtHero);
+			global::Gtk.Table.TableChild w27 = ((global::Gtk.Table.TableChild)(this.table3[this.txtHero]));
 			w27.LeftAttach = ((uint)(1));
 			w27.RightAttach = ((uint)(2));
 			w27.XOptions = ((global::Gtk.AttachOptions)(4));
 			w27.YOptions = ((global::Gtk.AttachOptions)(4));
-			this.vbox2.Add (this.table3);
-			global::Gtk.Box.BoxChild w28 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.table3]));
+			this.vbox2.Add(this.table3);
+			global::Gtk.Box.BoxChild w28 = ((global::Gtk.Box.BoxChild)(this.vbox2[this.table3]));
 			w28.Position = 1;
 			w28.Expand = false;
 			w28.Fill = false;
 			// Container child vbox2.Gtk.Box+BoxChild
-			this.vbox3 = new global::Gtk.VBox ();
+			this.vbox3 = new global::Gtk.VBox();
 			this.vbox3.Name = "vbox3";
 			this.vbox3.Spacing = 6;
-			this.vbox2.Add (this.vbox3);
-			global::Gtk.Box.BoxChild w29 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.vbox3]));
+			this.vbox2.Add(this.vbox3);
+			global::Gtk.Box.BoxChild w29 = ((global::Gtk.Box.BoxChild)(this.vbox2[this.vbox3]));
 			w29.Position = 2;
-			this.hbox4.Add (this.vbox2);
-			global::Gtk.Box.BoxChild w30 = ((global::Gtk.Box.BoxChild)(this.hbox4 [this.vbox2]));
+			this.hbox4.Add(this.vbox2);
+			global::Gtk.Box.BoxChild w30 = ((global::Gtk.Box.BoxChild)(this.hbox4[this.vbox2]));
 			w30.Position = 0;
 			w30.Expand = false;
 			w30.Fill = false;
 			// Container child hbox4.Gtk.Box+BoxChild
-			this.vbox4 = new global::Gtk.VBox ();
+			this.vbox4 = new global::Gtk.VBox();
 			this.vbox4.Name = "vbox4";
 			this.vbox4.Spacing = 6;
 			// Container child vbox4.Gtk.Box+BoxChild
-			this.hbox2 = new global::Gtk.HBox ();
+			this.hbox2 = new global::Gtk.HBox();
 			this.hbox2.Name = "hbox2";
 			this.hbox2.Spacing = 6;
 			// Container child hbox2.Gtk.Box+BoxChild
-			this.btnAllRings = new global::Gtk.Button ();
+			this.btnAllRings = new global::Gtk.Button();
 			this.btnAllRings.CanFocus = true;
 			this.btnAllRings.Name = "btnAllRings";
 			this.btnAllRings.UseUnderline = true;
-			this.btnAllRings.Label = global::Mono.Unix.Catalog.GetString ("All Rings");
-			this.hbox2.Add (this.btnAllRings);
-			global::Gtk.Box.BoxChild w31 = ((global::Gtk.Box.BoxChild)(this.hbox2 [this.btnAllRings]));
+			this.btnAllRings.Label = global::Mono.Unix.Catalog.GetString("All Rings");
+			this.hbox2.Add(this.btnAllRings);
+			global::Gtk.Box.BoxChild w31 = ((global::Gtk.Box.BoxChild)(this.hbox2[this.btnAllRings]));
 			w31.Position = 0;
 			w31.Expand = false;
 			w31.Fill = false;
 			// Container child hbox2.Gtk.Box+BoxChild
-			this.btnNoRings = new global::Gtk.Button ();
+			this.btnNoRings = new global::Gtk.Button();
 			this.btnNoRings.CanFocus = true;
 			this.btnNoRings.Name = "btnNoRings";
 			this.btnNoRings.UseUnderline = true;
-			this.btnNoRings.Label = global::Mono.Unix.Catalog.GetString ("None");
-			this.hbox2.Add (this.btnNoRings);
-			global::Gtk.Box.BoxChild w32 = ((global::Gtk.Box.BoxChild)(this.hbox2 [this.btnNoRings]));
+			this.btnNoRings.Label = global::Mono.Unix.Catalog.GetString("None");
+			this.hbox2.Add(this.btnNoRings);
+			global::Gtk.Box.BoxChild w32 = ((global::Gtk.Box.BoxChild)(this.hbox2[this.btnNoRings]));
 			w32.Position = 1;
 			w32.Expand = false;
 			w32.Fill = false;
-			this.vbox4.Add (this.hbox2);
-			global::Gtk.Box.BoxChild w33 = ((global::Gtk.Box.BoxChild)(this.vbox4 [this.hbox2]));
+			this.vbox4.Add(this.hbox2);
+			global::Gtk.Box.BoxChild w33 = ((global::Gtk.Box.BoxChild)(this.vbox4[this.hbox2]));
 			w33.Position = 0;
 			w33.Expand = false;
 			w33.Fill = false;
 			// Container child vbox4.Gtk.Box+BoxChild
-			this.GtkScrolledWindow = new global::Gtk.ScrolledWindow ();
+			this.GtkScrolledWindow = new global::Gtk.ScrolledWindow();
 			this.GtkScrolledWindow.WidthRequest = 170;
 			this.GtkScrolledWindow.Name = "GtkScrolledWindow";
 			this.GtkScrolledWindow.HscrollbarPolicy = ((global::Gtk.PolicyType)(2));
 			this.GtkScrolledWindow.ShadowType = ((global::Gtk.ShadowType)(1));
 			// Container child GtkScrolledWindow.Gtk.Container+ContainerChild
-			this.nvRings = new global::Gtk.NodeView ();
+			this.nvRings = new global::Gtk.NodeView();
 			this.nvRings.CanFocus = true;
 			this.nvRings.Name = "nvRings";
 			this.nvRings.HeadersVisible = false;
-			this.GtkScrolledWindow.Add (this.nvRings);
-			this.vbox4.Add (this.GtkScrolledWindow);
-			global::Gtk.Box.BoxChild w35 = ((global::Gtk.Box.BoxChild)(this.vbox4 [this.GtkScrolledWindow]));
+			this.GtkScrolledWindow.Add(this.nvRings);
+			this.vbox4.Add(this.GtkScrolledWindow);
+			global::Gtk.Box.BoxChild w35 = ((global::Gtk.Box.BoxChild)(this.vbox4[this.GtkScrolledWindow]));
 			w35.Position = 1;
 			// Container child vbox4.Gtk.Box+BoxChild
-			this.chkFreeRingGiven = new global::Gtk.CheckButton ();
+			this.chkFreeRingGiven = new global::Gtk.CheckButton();
 			this.chkFreeRingGiven.TooltipMarkup = "Whether or not Vasu has given the player the free Friendship Ring";
 			this.chkFreeRingGiven.CanFocus = true;
 			this.chkFreeRingGiven.Name = "chkFreeRingGiven";
-			this.chkFreeRingGiven.Label = global::Mono.Unix.Catalog.GetString ("Free Ring Given");
+			this.chkFreeRingGiven.Label = global::Mono.Unix.Catalog.GetString("Free Ring Given");
 			this.chkFreeRingGiven.DrawIndicator = true;
 			this.chkFreeRingGiven.UseUnderline = true;
-			this.vbox4.Add (this.chkFreeRingGiven);
-			global::Gtk.Box.BoxChild w36 = ((global::Gtk.Box.BoxChild)(this.vbox4 [this.chkFreeRingGiven]));
+			this.vbox4.Add(this.chkFreeRingGiven);
+			global::Gtk.Box.BoxChild w36 = ((global::Gtk.Box.BoxChild)(this.vbox4[this.chkFreeRingGiven]));
 			w36.Position = 2;
 			w36.Expand = false;
 			w36.Fill = false;
-			this.hbox4.Add (this.vbox4);
-			global::Gtk.Box.BoxChild w37 = ((global::Gtk.Box.BoxChild)(this.hbox4 [this.vbox4]));
+			this.hbox4.Add(this.vbox4);
+			global::Gtk.Box.BoxChild w37 = ((global::Gtk.Box.BoxChild)(this.hbox4[this.vbox4]));
 			w37.Position = 1;
-			this.vbox1.Add (this.hbox4);
-			global::Gtk.Box.BoxChild w38 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.hbox4]));
+			this.vbox1.Add(this.hbox4);
+			global::Gtk.Box.BoxChild w38 = ((global::Gtk.Box.BoxChild)(this.vbox1[this.hbox4]));
 			w38.Position = 1;
-			this.Add (this.vbox1);
-			if ((this.Child != null)) {
-				this.Child.ShowAll ();
+			this.Add(this.vbox1);
+			if ((this.Child != null))
+			{
+				this.Child.ShowAll();
 			}
-			this.DefaultWidth = 444;
-			this.DefaultHeight = 258;
-			this.Show ();
-			this.DeleteEvent += new global::Gtk.DeleteEventHandler (this.OnDeleteEvent);
-			this.newAction.Activated += new global::System.EventHandler (this.OnNew);
-			this.openAction.Activated += new global::System.EventHandler (this.OnOpen);
-			this.saveAction.Activated += new global::System.EventHandler (this.OnSave);
-			this.saveAsAction.Activated += new global::System.EventHandler (this.OnSaveAs);
-			this.quitAction.Activated += new global::System.EventHandler (this.OnQuit);
-			this.LoadGameSecretAction.Activated += new global::System.EventHandler (this.OnLoadGameSecret);
-			this.LoadRingSecretAction.Activated += new global::System.EventHandler (this.OnLoadRingSecret);
-			this.GenerateSecretsAction.Activated += new global::System.EventHandler (this.OnGenerateSecrets);
-			this.aboutAction.Activated += new global::System.EventHandler (this.OnAbout);
-			this.CheckForUpdatesAction.Activated += new global::System.EventHandler (this.OnCheckForUpdatesActionActivated);
-			this.importBatteryAction.Activated += new global::System.EventHandler (this.OnImportBattery);
+			this.DefaultWidth = 513;
+			this.DefaultHeight = 284;
+			this.Show();
+			this.DeleteEvent += new global::Gtk.DeleteEventHandler(this.OnDeleteEvent);
+			this.newAction.Activated += new global::System.EventHandler(this.OnNew);
+			this.openAction.Activated += new global::System.EventHandler(this.OnOpen);
+			this.saveAction.Activated += new global::System.EventHandler(this.OnSave);
+			this.saveAsAction.Activated += new global::System.EventHandler(this.OnSaveAs);
+			this.quitAction.Activated += new global::System.EventHandler(this.OnQuit);
+			this.LoadGameSecretAction.Activated += new global::System.EventHandler(this.OnLoadGameSecret);
+			this.LoadRingSecretAction.Activated += new global::System.EventHandler(this.OnLoadRingSecret);
+			this.GenerateSecretsAction.Activated += new global::System.EventHandler(this.OnGenerateSecrets);
+			this.aboutAction.Activated += new global::System.EventHandler(this.OnAbout);
+			this.CheckForUpdatesAction.Activated += new global::System.EventHandler(this.OnCheckForUpdatesActionActivated);
+			this.importBatteryAction.Activated += new global::System.EventHandler(this.OnImportBattery);
+			this.btnAllRings.Clicked += new global::System.EventHandler(this.OnBtnAllRingsClicked);
+			this.btnNoRings.Clicked += new global::System.EventHandler(this.OnBtnNoRingsClicked);
 		}
 	}
 }

--- a/ZoraGenGtk/gtk-gui/Zyrenth.ZoraGen.GtkUI.ViewSecretsDialog.cs
+++ b/ZoraGenGtk/gtk-gui/Zyrenth.ZoraGen.GtkUI.ViewSecretsDialog.cs
@@ -5,72 +5,96 @@ namespace Zyrenth.ZoraGen.GtkUI
 	public partial class ViewSecretsDialog
 	{
 		private global::Gtk.HBox hbox1;
-		
+
 		private global::Gtk.VBox vbox2;
-		
+
 		private global::Gtk.Label label1;
-		
+
 		private global::Zyrenth.ZoraGen.GtkUI.LargeSecretWidget swGame;
-		
+
 		private global::Gtk.Label label2;
-		
+
 		private global::Zyrenth.ZoraGen.GtkUI.LargeSecretWidget swRings;
-		
+
 		private global::Gtk.Label label4;
-		
+
+		private global::Gtk.Table table2;
+
+		private global::Gtk.Label label5;
+
+		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swSec1;
+
+		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swSec10;
+
+		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swSec2;
+
+		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swSec3;
+
+		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swSec4;
+
+		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swSec5;
+
+		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swSec6;
+
+		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swSec7;
+
+		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swSec8;
+
+		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swSec9;
+
 		private global::Gtk.Table table1;
-		
+
 		private global::Gtk.Label label3;
-		
+
 		private global::Gtk.Label lblMem1;
-		
+
 		private global::Gtk.Label lblMem10;
-		
+
 		private global::Gtk.Label lblMem2;
-		
+
 		private global::Gtk.Label lblMem3;
-		
+
 		private global::Gtk.Label lblMem4;
-		
+
 		private global::Gtk.Label lblMem5;
-		
+
 		private global::Gtk.Label lblMem6;
-		
+
 		private global::Gtk.Label lblMem7;
-		
+
 		private global::Gtk.Label lblMem8;
-		
+
 		private global::Gtk.Label lblMem9;
-		
+
 		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swMem1;
-		
+
 		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swMem10;
-		
+
 		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swMem2;
-		
+
 		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swMem3;
-		
+
 		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swMem4;
-		
+
 		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swMem5;
-		
+
 		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swMem6;
-		
+
 		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swMem7;
-		
+
 		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swMem8;
-		
+
 		private global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget swMem9;
-		
+
 		private global::Gtk.Button buttonOk;
 
-		protected virtual void Build ()
+		protected virtual void Build()
 		{
-			global::Stetic.Gui.Initialize (this);
+			global::Stetic.Gui.Initialize(this);
 			// Widget Zyrenth.ZoraGen.GtkUI.ViewSecretsDialog
 			this.Name = "Zyrenth.ZoraGen.GtkUI.ViewSecretsDialog";
-			this.Title = global::Mono.Unix.Catalog.GetString ("Generate Secrets");
-			this.Icon = global::Gdk.Pixbuf.LoadFromResource ("Zyrenth.ZoraGen.GtkUI.Farore.ico");
+			this.Title = global::Mono.Unix.Catalog.GetString("Generate Secrets");
+			this.Icon = global::Gdk.Pixbuf.LoadFromResource("Zyrenth.ZoraGen.GtkUI.Farore.ico");
 			this.WindowPosition = ((global::Gtk.WindowPosition)(4));
 			this.Modal = true;
 			this.DestroyWithParent = true;
@@ -79,351 +103,471 @@ namespace Zyrenth.ZoraGen.GtkUI
 			w1.Name = "dialog1_VBox";
 			w1.BorderWidth = ((uint)(2));
 			// Container child dialog1_VBox.Gtk.Box+BoxChild
-			this.hbox1 = new global::Gtk.HBox ();
+			this.hbox1 = new global::Gtk.HBox();
 			this.hbox1.Name = "hbox1";
 			this.hbox1.Spacing = 6;
 			this.hbox1.BorderWidth = ((uint)(8));
 			// Container child hbox1.Gtk.Box+BoxChild
-			this.vbox2 = new global::Gtk.VBox ();
+			this.vbox2 = new global::Gtk.VBox();
 			this.vbox2.Name = "vbox2";
 			this.vbox2.Spacing = 6;
 			// Container child vbox2.Gtk.Box+BoxChild
-			this.label1 = new global::Gtk.Label ();
+			this.label1 = new global::Gtk.Label();
 			this.label1.Name = "label1";
 			this.label1.Xalign = 0F;
-			this.label1.LabelProp = global::Mono.Unix.Catalog.GetString ("Secret to start game:");
-			this.vbox2.Add (this.label1);
-			global::Gtk.Box.BoxChild w2 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.label1]));
+			this.label1.LabelProp = global::Mono.Unix.Catalog.GetString("Secret to start game:");
+			this.vbox2.Add(this.label1);
+			global::Gtk.Box.BoxChild w2 = ((global::Gtk.Box.BoxChild)(this.vbox2[this.label1]));
 			w2.Position = 0;
 			w2.Expand = false;
 			w2.Fill = false;
 			// Container child vbox2.Gtk.Box+BoxChild
-			this.swGame = new global::Zyrenth.ZoraGen.GtkUI.LargeSecretWidget ();
+			this.swGame = new global::Zyrenth.ZoraGen.GtkUI.LargeSecretWidget();
 			this.swGame.WidthRequest = 172;
 			this.swGame.HeightRequest = 52;
 			this.swGame.Events = ((global::Gdk.EventMask)(256));
 			this.swGame.Name = "swGame";
-			this.vbox2.Add (this.swGame);
-			global::Gtk.Box.BoxChild w3 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.swGame]));
+			this.vbox2.Add(this.swGame);
+			global::Gtk.Box.BoxChild w3 = ((global::Gtk.Box.BoxChild)(this.vbox2[this.swGame]));
 			w3.Position = 1;
 			w3.Expand = false;
 			w3.Fill = false;
 			// Container child vbox2.Gtk.Box+BoxChild
-			this.label2 = new global::Gtk.Label ();
-			this.label2.Name = "label2";
+			this.label2 = new global::Gtk.Label();
 			this.label2.Xalign = 0F;
-			this.label2.LabelProp = global::Mono.Unix.Catalog.GetString ("Ring Secret:");
-			this.vbox2.Add (this.label2);
-			global::Gtk.Box.BoxChild w4 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.label2]));
+			this.label2.LabelProp = global::Mono.Unix.Catalog.GetString("Ring Secret:");
+			this.vbox2.Add(this.label2);
+			global::Gtk.Box.BoxChild w4 = ((global::Gtk.Box.BoxChild)(this.vbox2[this.label2]));
 			w4.Position = 2;
 			w4.Expand = false;
 			w4.Fill = false;
 			// Container child vbox2.Gtk.Box+BoxChild
-			this.swRings = new global::Zyrenth.ZoraGen.GtkUI.LargeSecretWidget ();
+			this.swRings = new global::Zyrenth.ZoraGen.GtkUI.LargeSecretWidget();
 			this.swRings.WidthRequest = 172;
 			this.swRings.HeightRequest = 52;
 			this.swRings.Events = ((global::Gdk.EventMask)(256));
 			this.swRings.Name = "swRings";
-			this.vbox2.Add (this.swRings);
-			global::Gtk.Box.BoxChild w5 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.swRings]));
+			this.vbox2.Add(this.swRings);
+			global::Gtk.Box.BoxChild w5 = ((global::Gtk.Box.BoxChild)(this.vbox2[this.swRings]));
 			w5.Position = 3;
 			w5.Expand = false;
 			w5.Fill = false;
 			// Container child vbox2.Gtk.Box+BoxChild
-			this.label4 = new global::Gtk.Label ();
+			this.label4 = new global::Gtk.Label();
 			this.label4.WidthRequest = 172;
 			this.label4.Name = "label4";
-			this.label4.LabelProp = global::Mono.Unix.Catalog.GetString ("Memory secrets can only be used AFTER you find the corresponding person in the game.");
+			this.label4.LabelProp = global::Mono.Unix.Catalog.GetString("Memory secrets can only be used AFTER you find the corresponding person in the game.");
 			this.label4.Wrap = true;
-			this.vbox2.Add (this.label4);
-			global::Gtk.Box.BoxChild w6 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.label4]));
+			this.vbox2.Add(this.label4);
+			global::Gtk.Box.BoxChild w6 = ((global::Gtk.Box.BoxChild)(this.vbox2[this.label4]));
 			w6.Position = 4;
 			w6.Expand = false;
 			w6.Fill = false;
-			this.hbox1.Add (this.vbox2);
-			global::Gtk.Box.BoxChild w7 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this.vbox2]));
+			this.hbox1.Add(this.vbox2);
+			global::Gtk.Box.BoxChild w7 = ((global::Gtk.Box.BoxChild)(this.hbox1[this.vbox2]));
 			w7.Position = 0;
 			w7.Expand = false;
 			w7.Fill = false;
 			// Container child hbox1.Gtk.Box+BoxChild
-			this.table1 = new global::Gtk.Table (((uint)(11)), ((uint)(2)), false);
-			this.table1.Name = "table1";
-			this.table1.RowSpacing = ((uint)(1));
-			this.table1.ColumnSpacing = ((uint)(6));
-			// Container child table1.Gtk.Table+TableChild
-			this.label3 = new global::Gtk.Label ();
-			this.label3.Name = "label3";
-			this.label3.Xalign = 0F;
-			this.label3.LabelProp = global::Mono.Unix.Catalog.GetString ("Memories:");
-			this.table1.Add (this.label3);
-			global::Gtk.Table.TableChild w8 = ((global::Gtk.Table.TableChild)(this.table1 [this.label3]));
+			this.table2 = new global::Gtk.Table(((uint)(11)), ((uint)(1)), false);
+			this.table2.Name = "table2";
+			this.table2.RowSpacing = ((uint)(1));
+			this.table2.ColumnSpacing = ((uint)(6));
+			// Container child table2.Gtk.Table+TableChild
+			this.label5 = new global::Gtk.Label();
+			this.label5.Name = "label5";
+			this.label5.LabelProp = global::Mono.Unix.Catalog.GetString("Secret\n(for Game1)");
+			this.label5.Justify = ((global::Gtk.Justification)(2));
+			this.table2.Add(this.label5);
+			global::Gtk.Table.TableChild w8 = ((global::Gtk.Table.TableChild)(this.table2[this.label5]));
 			w8.XOptions = ((global::Gtk.AttachOptions)(4));
 			w8.YOptions = ((global::Gtk.AttachOptions)(4));
-			// Container child table1.Gtk.Table+TableChild
-			this.lblMem1 = new global::Gtk.Label ();
-			this.lblMem1.Name = "lblMem1";
-			this.lblMem1.Xalign = 0F;
-			this.lblMem1.LabelProp = global::Mono.Unix.Catalog.GetString ("label1");
-			this.table1.Add (this.lblMem1);
-			global::Gtk.Table.TableChild w9 = ((global::Gtk.Table.TableChild)(this.table1 [this.lblMem1]));
+			// Container child table2.Gtk.Table+TableChild
+			this.swSec1 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swSec1.Events = ((global::Gdk.EventMask)(256));
+			this.swSec1.Name = "swSec1";
+			this.table2.Add(this.swSec1);
+			global::Gtk.Table.TableChild w9 = ((global::Gtk.Table.TableChild)(this.table2[this.swSec1]));
 			w9.TopAttach = ((uint)(1));
 			w9.BottomAttach = ((uint)(2));
-			w9.LeftAttach = ((uint)(1));
-			w9.RightAttach = ((uint)(2));
 			w9.XOptions = ((global::Gtk.AttachOptions)(4));
 			w9.YOptions = ((global::Gtk.AttachOptions)(4));
-			// Container child table1.Gtk.Table+TableChild
-			this.lblMem10 = new global::Gtk.Label ();
-			this.lblMem10.Name = "lblMem10";
-			this.lblMem10.Xalign = 0F;
-			this.lblMem10.LabelProp = global::Mono.Unix.Catalog.GetString ("label10");
-			this.table1.Add (this.lblMem10);
-			global::Gtk.Table.TableChild w10 = ((global::Gtk.Table.TableChild)(this.table1 [this.lblMem10]));
+			// Container child table2.Gtk.Table+TableChild
+			this.swSec10 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swSec10.Events = ((global::Gdk.EventMask)(256));
+			this.swSec10.Name = "swSec10";
+			this.table2.Add(this.swSec10);
+			global::Gtk.Table.TableChild w10 = ((global::Gtk.Table.TableChild)(this.table2[this.swSec10]));
 			w10.TopAttach = ((uint)(10));
 			w10.BottomAttach = ((uint)(11));
-			w10.LeftAttach = ((uint)(1));
-			w10.RightAttach = ((uint)(2));
 			w10.XOptions = ((global::Gtk.AttachOptions)(4));
 			w10.YOptions = ((global::Gtk.AttachOptions)(4));
-			// Container child table1.Gtk.Table+TableChild
-			this.lblMem2 = new global::Gtk.Label ();
-			this.lblMem2.Name = "lblMem2";
-			this.lblMem2.Xalign = 0F;
-			this.lblMem2.LabelProp = global::Mono.Unix.Catalog.GetString ("label2");
-			this.table1.Add (this.lblMem2);
-			global::Gtk.Table.TableChild w11 = ((global::Gtk.Table.TableChild)(this.table1 [this.lblMem2]));
+			// Container child table2.Gtk.Table+TableChild
+			this.swSec2 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swSec2.Events = ((global::Gdk.EventMask)(256));
+			this.swSec2.Name = "swSec2";
+			this.table2.Add(this.swSec2);
+			global::Gtk.Table.TableChild w11 = ((global::Gtk.Table.TableChild)(this.table2[this.swSec2]));
 			w11.TopAttach = ((uint)(2));
 			w11.BottomAttach = ((uint)(3));
-			w11.LeftAttach = ((uint)(1));
-			w11.RightAttach = ((uint)(2));
 			w11.XOptions = ((global::Gtk.AttachOptions)(4));
 			w11.YOptions = ((global::Gtk.AttachOptions)(4));
-			// Container child table1.Gtk.Table+TableChild
-			this.lblMem3 = new global::Gtk.Label ();
-			this.lblMem3.Name = "lblMem3";
-			this.lblMem3.Xalign = 0F;
-			this.lblMem3.LabelProp = global::Mono.Unix.Catalog.GetString ("label3");
-			this.table1.Add (this.lblMem3);
-			global::Gtk.Table.TableChild w12 = ((global::Gtk.Table.TableChild)(this.table1 [this.lblMem3]));
+			// Container child table2.Gtk.Table+TableChild
+			this.swSec3 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swSec3.Events = ((global::Gdk.EventMask)(256));
+			this.swSec3.Name = "swSec3";
+			this.table2.Add(this.swSec3);
+			global::Gtk.Table.TableChild w12 = ((global::Gtk.Table.TableChild)(this.table2[this.swSec3]));
 			w12.TopAttach = ((uint)(3));
 			w12.BottomAttach = ((uint)(4));
-			w12.LeftAttach = ((uint)(1));
-			w12.RightAttach = ((uint)(2));
 			w12.XOptions = ((global::Gtk.AttachOptions)(4));
 			w12.YOptions = ((global::Gtk.AttachOptions)(4));
-			// Container child table1.Gtk.Table+TableChild
-			this.lblMem4 = new global::Gtk.Label ();
-			this.lblMem4.Name = "lblMem4";
-			this.lblMem4.Xalign = 0F;
-			this.lblMem4.LabelProp = global::Mono.Unix.Catalog.GetString ("label4");
-			this.table1.Add (this.lblMem4);
-			global::Gtk.Table.TableChild w13 = ((global::Gtk.Table.TableChild)(this.table1 [this.lblMem4]));
+			// Container child table2.Gtk.Table+TableChild
+			this.swSec4 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swSec4.Events = ((global::Gdk.EventMask)(256));
+			this.swSec4.Name = "swSec4";
+			this.table2.Add(this.swSec4);
+			global::Gtk.Table.TableChild w13 = ((global::Gtk.Table.TableChild)(this.table2[this.swSec4]));
 			w13.TopAttach = ((uint)(4));
 			w13.BottomAttach = ((uint)(5));
-			w13.LeftAttach = ((uint)(1));
-			w13.RightAttach = ((uint)(2));
 			w13.XOptions = ((global::Gtk.AttachOptions)(4));
 			w13.YOptions = ((global::Gtk.AttachOptions)(4));
-			// Container child table1.Gtk.Table+TableChild
-			this.lblMem5 = new global::Gtk.Label ();
-			this.lblMem5.Name = "lblMem5";
-			this.lblMem5.Xalign = 0F;
-			this.lblMem5.LabelProp = global::Mono.Unix.Catalog.GetString ("label5");
-			this.table1.Add (this.lblMem5);
-			global::Gtk.Table.TableChild w14 = ((global::Gtk.Table.TableChild)(this.table1 [this.lblMem5]));
+			// Container child table2.Gtk.Table+TableChild
+			this.swSec5 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swSec5.Events = ((global::Gdk.EventMask)(256));
+			this.swSec5.Name = "swSec5";
+			this.table2.Add(this.swSec5);
+			global::Gtk.Table.TableChild w14 = ((global::Gtk.Table.TableChild)(this.table2[this.swSec5]));
 			w14.TopAttach = ((uint)(5));
 			w14.BottomAttach = ((uint)(6));
-			w14.LeftAttach = ((uint)(1));
-			w14.RightAttach = ((uint)(2));
 			w14.XOptions = ((global::Gtk.AttachOptions)(4));
 			w14.YOptions = ((global::Gtk.AttachOptions)(4));
-			// Container child table1.Gtk.Table+TableChild
-			this.lblMem6 = new global::Gtk.Label ();
-			this.lblMem6.Name = "lblMem6";
-			this.lblMem6.Xalign = 0F;
-			this.lblMem6.LabelProp = global::Mono.Unix.Catalog.GetString ("label6");
-			this.table1.Add (this.lblMem6);
-			global::Gtk.Table.TableChild w15 = ((global::Gtk.Table.TableChild)(this.table1 [this.lblMem6]));
+			// Container child table2.Gtk.Table+TableChild
+			this.swSec6 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swSec6.Events = ((global::Gdk.EventMask)(256));
+			this.swSec6.Name = "swSec6";
+			this.table2.Add(this.swSec6);
+			global::Gtk.Table.TableChild w15 = ((global::Gtk.Table.TableChild)(this.table2[this.swSec6]));
 			w15.TopAttach = ((uint)(6));
 			w15.BottomAttach = ((uint)(7));
-			w15.LeftAttach = ((uint)(1));
-			w15.RightAttach = ((uint)(2));
 			w15.XOptions = ((global::Gtk.AttachOptions)(4));
 			w15.YOptions = ((global::Gtk.AttachOptions)(4));
-			// Container child table1.Gtk.Table+TableChild
-			this.lblMem7 = new global::Gtk.Label ();
-			this.lblMem7.Name = "lblMem7";
-			this.lblMem7.Xalign = 0F;
-			this.lblMem7.LabelProp = global::Mono.Unix.Catalog.GetString ("label7");
-			this.table1.Add (this.lblMem7);
-			global::Gtk.Table.TableChild w16 = ((global::Gtk.Table.TableChild)(this.table1 [this.lblMem7]));
+			// Container child table2.Gtk.Table+TableChild
+			this.swSec7 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swSec7.Events = ((global::Gdk.EventMask)(256));
+			this.swSec7.Name = "swSec7";
+			this.table2.Add(this.swSec7);
+			global::Gtk.Table.TableChild w16 = ((global::Gtk.Table.TableChild)(this.table2[this.swSec7]));
 			w16.TopAttach = ((uint)(7));
 			w16.BottomAttach = ((uint)(8));
-			w16.LeftAttach = ((uint)(1));
-			w16.RightAttach = ((uint)(2));
 			w16.XOptions = ((global::Gtk.AttachOptions)(4));
 			w16.YOptions = ((global::Gtk.AttachOptions)(4));
-			// Container child table1.Gtk.Table+TableChild
-			this.lblMem8 = new global::Gtk.Label ();
-			this.lblMem8.Name = "lblMem8";
-			this.lblMem8.Xalign = 0F;
-			this.lblMem8.LabelProp = global::Mono.Unix.Catalog.GetString ("label8");
-			this.table1.Add (this.lblMem8);
-			global::Gtk.Table.TableChild w17 = ((global::Gtk.Table.TableChild)(this.table1 [this.lblMem8]));
+			// Container child table2.Gtk.Table+TableChild
+			this.swSec8 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swSec8.Events = ((global::Gdk.EventMask)(256));
+			this.swSec8.Name = "swSec8";
+			this.table2.Add(this.swSec8);
+			global::Gtk.Table.TableChild w17 = ((global::Gtk.Table.TableChild)(this.table2[this.swSec8]));
 			w17.TopAttach = ((uint)(8));
 			w17.BottomAttach = ((uint)(9));
-			w17.LeftAttach = ((uint)(1));
-			w17.RightAttach = ((uint)(2));
 			w17.XOptions = ((global::Gtk.AttachOptions)(4));
 			w17.YOptions = ((global::Gtk.AttachOptions)(4));
-			// Container child table1.Gtk.Table+TableChild
-			this.lblMem9 = new global::Gtk.Label ();
-			this.lblMem9.Name = "lblMem9";
-			this.lblMem9.Xalign = 0F;
-			this.lblMem9.LabelProp = global::Mono.Unix.Catalog.GetString ("label9");
-			this.table1.Add (this.lblMem9);
-			global::Gtk.Table.TableChild w18 = ((global::Gtk.Table.TableChild)(this.table1 [this.lblMem9]));
+			// Container child table2.Gtk.Table+TableChild
+			this.swSec9 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swSec9.Events = ((global::Gdk.EventMask)(256));
+			this.swSec9.Name = "swSec9";
+			this.table2.Add(this.swSec9);
+			global::Gtk.Table.TableChild w18 = ((global::Gtk.Table.TableChild)(this.table2[this.swSec9]));
 			w18.TopAttach = ((uint)(9));
 			w18.BottomAttach = ((uint)(10));
-			w18.LeftAttach = ((uint)(1));
-			w18.RightAttach = ((uint)(2));
 			w18.XOptions = ((global::Gtk.AttachOptions)(4));
 			w18.YOptions = ((global::Gtk.AttachOptions)(4));
+			this.hbox1.Add(this.table2);
+			global::Gtk.Box.BoxChild w19 = ((global::Gtk.Box.BoxChild)(this.hbox1[this.table2]));
+			w19.Position = 1;
+			w19.Expand = false;
+			w19.Fill = false;
+			w19.Padding = ((uint)(6));
+			// Container child hbox1.Gtk.Box+BoxChild
+			this.table1 = new global::Gtk.Table(((uint)(11)), ((uint)(2)), false);
+			this.table1.Name = "table1";
+			this.table1.RowSpacing = ((uint)(1));
+			this.table1.ColumnSpacing = ((uint)(8));
 			// Container child table1.Gtk.Table+TableChild
-			this.swMem1 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget ();
-			this.swMem1.Events = ((global::Gdk.EventMask)(256));
-			this.swMem1.Name = "swMem1";
-			this.table1.Add (this.swMem1);
-			global::Gtk.Table.TableChild w19 = ((global::Gtk.Table.TableChild)(this.table1 [this.swMem1]));
-			w19.TopAttach = ((uint)(1));
-			w19.BottomAttach = ((uint)(2));
-			w19.XOptions = ((global::Gtk.AttachOptions)(4));
-			w19.YOptions = ((global::Gtk.AttachOptions)(4));
-			// Container child table1.Gtk.Table+TableChild
-			this.swMem10 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget ();
-			this.swMem10.Events = ((global::Gdk.EventMask)(256));
-			this.swMem10.Name = "swMem10";
-			this.table1.Add (this.swMem10);
-			global::Gtk.Table.TableChild w20 = ((global::Gtk.Table.TableChild)(this.table1 [this.swMem10]));
-			w20.TopAttach = ((uint)(10));
-			w20.BottomAttach = ((uint)(11));
+			this.label3 = new global::Gtk.Label();
+			this.label3.Name = "label3";
+			this.label3.LabelProp = global::Mono.Unix.Catalog.GetString("Memories\n(for Game2)");
+			this.label3.Justify = ((global::Gtk.Justification)(2));
+			this.table1.Add(this.label3);
+			global::Gtk.Table.TableChild w20 = ((global::Gtk.Table.TableChild)(this.table1[this.label3]));
 			w20.XOptions = ((global::Gtk.AttachOptions)(4));
 			w20.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
-			this.swMem2 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget ();
-			this.swMem2.Events = ((global::Gdk.EventMask)(256));
-			this.swMem2.Name = "swMem2";
-			this.table1.Add (this.swMem2);
-			global::Gtk.Table.TableChild w21 = ((global::Gtk.Table.TableChild)(this.table1 [this.swMem2]));
-			w21.TopAttach = ((uint)(2));
-			w21.BottomAttach = ((uint)(3));
+			this.lblMem1 = new global::Gtk.Label();
+			this.lblMem1.Name = "lblMem1";
+			this.lblMem1.Xalign = 0F;
+			this.lblMem1.LabelProp = global::Mono.Unix.Catalog.GetString("label1");
+			this.table1.Add(this.lblMem1);
+			global::Gtk.Table.TableChild w21 = ((global::Gtk.Table.TableChild)(this.table1[this.lblMem1]));
+			w21.TopAttach = ((uint)(1));
+			w21.BottomAttach = ((uint)(2));
+			w21.LeftAttach = ((uint)(1));
+			w21.RightAttach = ((uint)(2));
 			w21.XOptions = ((global::Gtk.AttachOptions)(4));
 			w21.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
-			this.swMem3 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget ();
-			this.swMem3.Events = ((global::Gdk.EventMask)(256));
-			this.swMem3.Name = "swMem3";
-			this.table1.Add (this.swMem3);
-			global::Gtk.Table.TableChild w22 = ((global::Gtk.Table.TableChild)(this.table1 [this.swMem3]));
-			w22.TopAttach = ((uint)(3));
-			w22.BottomAttach = ((uint)(4));
+			this.lblMem10 = new global::Gtk.Label();
+			this.lblMem10.Name = "lblMem10";
+			this.lblMem10.Xalign = 0F;
+			this.lblMem10.LabelProp = global::Mono.Unix.Catalog.GetString("label10");
+			this.table1.Add(this.lblMem10);
+			global::Gtk.Table.TableChild w22 = ((global::Gtk.Table.TableChild)(this.table1[this.lblMem10]));
+			w22.TopAttach = ((uint)(10));
+			w22.BottomAttach = ((uint)(11));
+			w22.LeftAttach = ((uint)(1));
+			w22.RightAttach = ((uint)(2));
 			w22.XOptions = ((global::Gtk.AttachOptions)(4));
 			w22.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
-			this.swMem4 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget ();
-			this.swMem4.Events = ((global::Gdk.EventMask)(256));
-			this.swMem4.Name = "swMem4";
-			this.table1.Add (this.swMem4);
-			global::Gtk.Table.TableChild w23 = ((global::Gtk.Table.TableChild)(this.table1 [this.swMem4]));
-			w23.TopAttach = ((uint)(4));
-			w23.BottomAttach = ((uint)(5));
+			this.lblMem2 = new global::Gtk.Label();
+			this.lblMem2.Name = "lblMem2";
+			this.lblMem2.Xalign = 0F;
+			this.lblMem2.LabelProp = "";
+			this.table1.Add(this.lblMem2);
+			global::Gtk.Table.TableChild w23 = ((global::Gtk.Table.TableChild)(this.table1[this.lblMem2]));
+			w23.TopAttach = ((uint)(2));
+			w23.BottomAttach = ((uint)(3));
+			w23.LeftAttach = ((uint)(1));
+			w23.RightAttach = ((uint)(2));
 			w23.XOptions = ((global::Gtk.AttachOptions)(4));
 			w23.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
-			this.swMem5 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget ();
-			this.swMem5.Events = ((global::Gdk.EventMask)(256));
-			this.swMem5.Name = "swMem5";
-			this.table1.Add (this.swMem5);
-			global::Gtk.Table.TableChild w24 = ((global::Gtk.Table.TableChild)(this.table1 [this.swMem5]));
-			w24.TopAttach = ((uint)(5));
-			w24.BottomAttach = ((uint)(6));
+			this.lblMem3 = new global::Gtk.Label();
+			this.lblMem3.Name = "lblMem3";
+			this.lblMem3.Xalign = 0F;
+			this.lblMem3.LabelProp = global::Mono.Unix.Catalog.GetString("label3");
+			this.table1.Add(this.lblMem3);
+			global::Gtk.Table.TableChild w24 = ((global::Gtk.Table.TableChild)(this.table1[this.lblMem3]));
+			w24.TopAttach = ((uint)(3));
+			w24.BottomAttach = ((uint)(4));
+			w24.LeftAttach = ((uint)(1));
+			w24.RightAttach = ((uint)(2));
 			w24.XOptions = ((global::Gtk.AttachOptions)(4));
 			w24.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
-			this.swMem6 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget ();
-			this.swMem6.Events = ((global::Gdk.EventMask)(256));
-			this.swMem6.Name = "swMem6";
-			this.table1.Add (this.swMem6);
-			global::Gtk.Table.TableChild w25 = ((global::Gtk.Table.TableChild)(this.table1 [this.swMem6]));
-			w25.TopAttach = ((uint)(6));
-			w25.BottomAttach = ((uint)(7));
+			this.lblMem4 = new global::Gtk.Label();
+			this.lblMem4.Name = "lblMem4";
+			this.lblMem4.Xalign = 0F;
+			this.lblMem4.LabelProp = global::Mono.Unix.Catalog.GetString("label4");
+			this.table1.Add(this.lblMem4);
+			global::Gtk.Table.TableChild w25 = ((global::Gtk.Table.TableChild)(this.table1[this.lblMem4]));
+			w25.TopAttach = ((uint)(4));
+			w25.BottomAttach = ((uint)(5));
+			w25.LeftAttach = ((uint)(1));
+			w25.RightAttach = ((uint)(2));
 			w25.XOptions = ((global::Gtk.AttachOptions)(4));
 			w25.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
-			this.swMem7 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget ();
-			this.swMem7.Events = ((global::Gdk.EventMask)(256));
-			this.swMem7.Name = "swMem7";
-			this.table1.Add (this.swMem7);
-			global::Gtk.Table.TableChild w26 = ((global::Gtk.Table.TableChild)(this.table1 [this.swMem7]));
-			w26.TopAttach = ((uint)(7));
-			w26.BottomAttach = ((uint)(8));
+			this.lblMem5 = new global::Gtk.Label();
+			this.lblMem5.Name = "lblMem5";
+			this.lblMem5.Xalign = 0F;
+			this.lblMem5.LabelProp = global::Mono.Unix.Catalog.GetString("label5");
+			this.table1.Add(this.lblMem5);
+			global::Gtk.Table.TableChild w26 = ((global::Gtk.Table.TableChild)(this.table1[this.lblMem5]));
+			w26.TopAttach = ((uint)(5));
+			w26.BottomAttach = ((uint)(6));
+			w26.LeftAttach = ((uint)(1));
+			w26.RightAttach = ((uint)(2));
 			w26.XOptions = ((global::Gtk.AttachOptions)(4));
 			w26.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
-			this.swMem8 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget ();
-			this.swMem8.Events = ((global::Gdk.EventMask)(256));
-			this.swMem8.Name = "swMem8";
-			this.table1.Add (this.swMem8);
-			global::Gtk.Table.TableChild w27 = ((global::Gtk.Table.TableChild)(this.table1 [this.swMem8]));
-			w27.TopAttach = ((uint)(8));
-			w27.BottomAttach = ((uint)(9));
+			this.lblMem6 = new global::Gtk.Label();
+			this.lblMem6.Name = "lblMem6";
+			this.lblMem6.Xalign = 0F;
+			this.lblMem6.LabelProp = global::Mono.Unix.Catalog.GetString("label6");
+			this.table1.Add(this.lblMem6);
+			global::Gtk.Table.TableChild w27 = ((global::Gtk.Table.TableChild)(this.table1[this.lblMem6]));
+			w27.TopAttach = ((uint)(6));
+			w27.BottomAttach = ((uint)(7));
+			w27.LeftAttach = ((uint)(1));
+			w27.RightAttach = ((uint)(2));
 			w27.XOptions = ((global::Gtk.AttachOptions)(4));
 			w27.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
-			this.swMem9 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget ();
-			this.swMem9.Events = ((global::Gdk.EventMask)(256));
-			this.swMem9.Name = "swMem9";
-			this.table1.Add (this.swMem9);
-			global::Gtk.Table.TableChild w28 = ((global::Gtk.Table.TableChild)(this.table1 [this.swMem9]));
-			w28.TopAttach = ((uint)(9));
-			w28.BottomAttach = ((uint)(10));
+			this.lblMem7 = new global::Gtk.Label();
+			this.lblMem7.Name = "lblMem7";
+			this.lblMem7.Xalign = 0F;
+			this.lblMem7.LabelProp = global::Mono.Unix.Catalog.GetString("label7");
+			this.table1.Add(this.lblMem7);
+			global::Gtk.Table.TableChild w28 = ((global::Gtk.Table.TableChild)(this.table1[this.lblMem7]));
+			w28.TopAttach = ((uint)(7));
+			w28.BottomAttach = ((uint)(8));
+			w28.LeftAttach = ((uint)(1));
+			w28.RightAttach = ((uint)(2));
 			w28.XOptions = ((global::Gtk.AttachOptions)(4));
 			w28.YOptions = ((global::Gtk.AttachOptions)(4));
-			this.hbox1.Add (this.table1);
-			global::Gtk.Box.BoxChild w29 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this.table1]));
-			w29.Position = 1;
-			w29.Expand = false;
-			w29.Fill = false;
-			w1.Add (this.hbox1);
-			global::Gtk.Box.BoxChild w30 = ((global::Gtk.Box.BoxChild)(w1 [this.hbox1]));
-			w30.Position = 0;
-			w30.Expand = false;
-			w30.Fill = false;
+			// Container child table1.Gtk.Table+TableChild
+			this.lblMem8 = new global::Gtk.Label();
+			this.lblMem8.Name = "lblMem8";
+			this.lblMem8.Xalign = 0F;
+			this.lblMem8.LabelProp = global::Mono.Unix.Catalog.GetString("label8");
+			this.table1.Add(this.lblMem8);
+			global::Gtk.Table.TableChild w29 = ((global::Gtk.Table.TableChild)(this.table1[this.lblMem8]));
+			w29.TopAttach = ((uint)(8));
+			w29.BottomAttach = ((uint)(9));
+			w29.LeftAttach = ((uint)(1));
+			w29.RightAttach = ((uint)(2));
+			w29.XOptions = ((global::Gtk.AttachOptions)(4));
+			w29.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table1.Gtk.Table+TableChild
+			this.lblMem9 = new global::Gtk.Label();
+			this.lblMem9.Name = "lblMem9";
+			this.lblMem9.Xalign = 0F;
+			this.lblMem9.LabelProp = global::Mono.Unix.Catalog.GetString("label9");
+			this.table1.Add(this.lblMem9);
+			global::Gtk.Table.TableChild w30 = ((global::Gtk.Table.TableChild)(this.table1[this.lblMem9]));
+			w30.TopAttach = ((uint)(9));
+			w30.BottomAttach = ((uint)(10));
+			w30.LeftAttach = ((uint)(1));
+			w30.RightAttach = ((uint)(2));
+			w30.XOptions = ((global::Gtk.AttachOptions)(4));
+			w30.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table1.Gtk.Table+TableChild
+			this.swMem1 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swMem1.Events = ((global::Gdk.EventMask)(256));
+			this.swMem1.Name = "swMem1";
+			this.table1.Add(this.swMem1);
+			global::Gtk.Table.TableChild w31 = ((global::Gtk.Table.TableChild)(this.table1[this.swMem1]));
+			w31.TopAttach = ((uint)(1));
+			w31.BottomAttach = ((uint)(2));
+			w31.XOptions = ((global::Gtk.AttachOptions)(4));
+			w31.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table1.Gtk.Table+TableChild
+			this.swMem10 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swMem10.Events = ((global::Gdk.EventMask)(256));
+			this.swMem10.Name = "swMem10";
+			this.table1.Add(this.swMem10);
+			global::Gtk.Table.TableChild w32 = ((global::Gtk.Table.TableChild)(this.table1[this.swMem10]));
+			w32.TopAttach = ((uint)(10));
+			w32.BottomAttach = ((uint)(11));
+			w32.XOptions = ((global::Gtk.AttachOptions)(4));
+			w32.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table1.Gtk.Table+TableChild
+			this.swMem2 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swMem2.Events = ((global::Gdk.EventMask)(256));
+			this.swMem2.Name = "swMem2";
+			this.table1.Add(this.swMem2);
+			global::Gtk.Table.TableChild w33 = ((global::Gtk.Table.TableChild)(this.table1[this.swMem2]));
+			w33.TopAttach = ((uint)(2));
+			w33.BottomAttach = ((uint)(3));
+			w33.XOptions = ((global::Gtk.AttachOptions)(4));
+			w33.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table1.Gtk.Table+TableChild
+			this.swMem3 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swMem3.Events = ((global::Gdk.EventMask)(256));
+			this.swMem3.Name = "swMem3";
+			this.table1.Add(this.swMem3);
+			global::Gtk.Table.TableChild w34 = ((global::Gtk.Table.TableChild)(this.table1[this.swMem3]));
+			w34.TopAttach = ((uint)(3));
+			w34.BottomAttach = ((uint)(4));
+			w34.XOptions = ((global::Gtk.AttachOptions)(4));
+			w34.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table1.Gtk.Table+TableChild
+			this.swMem4 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swMem4.Events = ((global::Gdk.EventMask)(256));
+			this.swMem4.Name = "swMem4";
+			this.table1.Add(this.swMem4);
+			global::Gtk.Table.TableChild w35 = ((global::Gtk.Table.TableChild)(this.table1[this.swMem4]));
+			w35.TopAttach = ((uint)(4));
+			w35.BottomAttach = ((uint)(5));
+			w35.XOptions = ((global::Gtk.AttachOptions)(4));
+			w35.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table1.Gtk.Table+TableChild
+			this.swMem5 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swMem5.Events = ((global::Gdk.EventMask)(256));
+			this.swMem5.Name = "swMem5";
+			this.table1.Add(this.swMem5);
+			global::Gtk.Table.TableChild w36 = ((global::Gtk.Table.TableChild)(this.table1[this.swMem5]));
+			w36.TopAttach = ((uint)(5));
+			w36.BottomAttach = ((uint)(6));
+			w36.XOptions = ((global::Gtk.AttachOptions)(4));
+			w36.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table1.Gtk.Table+TableChild
+			this.swMem6 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swMem6.Events = ((global::Gdk.EventMask)(256));
+			this.swMem6.Name = "swMem6";
+			this.table1.Add(this.swMem6);
+			global::Gtk.Table.TableChild w37 = ((global::Gtk.Table.TableChild)(this.table1[this.swMem6]));
+			w37.TopAttach = ((uint)(6));
+			w37.BottomAttach = ((uint)(7));
+			w37.XOptions = ((global::Gtk.AttachOptions)(4));
+			w37.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table1.Gtk.Table+TableChild
+			this.swMem7 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swMem7.Events = ((global::Gdk.EventMask)(256));
+			this.swMem7.Name = "swMem7";
+			this.table1.Add(this.swMem7);
+			global::Gtk.Table.TableChild w38 = ((global::Gtk.Table.TableChild)(this.table1[this.swMem7]));
+			w38.TopAttach = ((uint)(7));
+			w38.BottomAttach = ((uint)(8));
+			w38.XOptions = ((global::Gtk.AttachOptions)(4));
+			w38.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table1.Gtk.Table+TableChild
+			this.swMem8 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swMem8.Events = ((global::Gdk.EventMask)(256));
+			this.swMem8.Name = "swMem8";
+			this.table1.Add(this.swMem8);
+			global::Gtk.Table.TableChild w39 = ((global::Gtk.Table.TableChild)(this.table1[this.swMem8]));
+			w39.TopAttach = ((uint)(8));
+			w39.BottomAttach = ((uint)(9));
+			w39.XOptions = ((global::Gtk.AttachOptions)(4));
+			w39.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table1.Gtk.Table+TableChild
+			this.swMem9 = new global::Zyrenth.ZoraGen.GtkUI.SmallSecretWidget();
+			this.swMem9.Events = ((global::Gdk.EventMask)(256));
+			this.swMem9.Name = "swMem9";
+			this.table1.Add(this.swMem9);
+			global::Gtk.Table.TableChild w40 = ((global::Gtk.Table.TableChild)(this.table1[this.swMem9]));
+			w40.TopAttach = ((uint)(9));
+			w40.BottomAttach = ((uint)(10));
+			w40.XOptions = ((global::Gtk.AttachOptions)(4));
+			w40.YOptions = ((global::Gtk.AttachOptions)(4));
+			this.hbox1.Add(this.table1);
+			global::Gtk.Box.BoxChild w41 = ((global::Gtk.Box.BoxChild)(this.hbox1[this.table1]));
+			w41.Position = 2;
+			w41.Expand = false;
+			w41.Fill = false;
+			w1.Add(this.hbox1);
+			global::Gtk.Box.BoxChild w42 = ((global::Gtk.Box.BoxChild)(w1[this.hbox1]));
+			w42.Position = 0;
+			w42.Expand = false;
+			w42.Fill = false;
 			// Internal child Zyrenth.ZoraGen.GtkUI.ViewSecretsDialog.ActionArea
-			global::Gtk.HButtonBox w31 = this.ActionArea;
-			w31.Name = "dialog1_ActionArea";
-			w31.Spacing = 10;
-			w31.BorderWidth = ((uint)(5));
-			w31.LayoutStyle = ((global::Gtk.ButtonBoxStyle)(4));
+			global::Gtk.HButtonBox w43 = this.ActionArea;
+			w43.Name = "dialog1_ActionArea";
+			w43.Spacing = 10;
+			w43.BorderWidth = ((uint)(5));
+			w43.LayoutStyle = ((global::Gtk.ButtonBoxStyle)(4));
 			// Container child dialog1_ActionArea.Gtk.ButtonBox+ButtonBoxChild
-			this.buttonOk = new global::Gtk.Button ();
+			this.buttonOk = new global::Gtk.Button();
 			this.buttonOk.CanDefault = true;
 			this.buttonOk.CanFocus = true;
 			this.buttonOk.Name = "buttonOk";
 			this.buttonOk.UseStock = true;
 			this.buttonOk.UseUnderline = true;
 			this.buttonOk.Label = "gtk-ok";
-			this.AddActionWidget (this.buttonOk, -5);
-			global::Gtk.ButtonBox.ButtonBoxChild w32 = ((global::Gtk.ButtonBox.ButtonBoxChild)(w31 [this.buttonOk]));
-			w32.Expand = false;
-			w32.Fill = false;
-			if ((this.Child != null)) {
-				this.Child.ShowAll ();
+			this.AddActionWidget(this.buttonOk, -5);
+			global::Gtk.ButtonBox.ButtonBoxChild w44 = ((global::Gtk.ButtonBox.ButtonBoxChild)(w43[this.buttonOk]));
+			w44.Expand = false;
+			w44.Fill = false;
+			if ((this.Child != null))
+			{
+				this.Child.ShowAll();
 			}
-			this.DefaultWidth = 305;
-			this.DefaultHeight = 286;
-			this.Show ();
-			this.buttonOk.Pressed += new global::System.EventHandler (this.OnButtonOkPressed);
+			this.DefaultWidth = 444;
+			this.DefaultHeight = 311;
+			this.Show();
+			this.buttonOk.Pressed += new global::System.EventHandler(this.OnButtonOkPressed);
 		}
 	}
 }

--- a/ZoraGenGtk/gtk-gui/generated.cs
+++ b/ZoraGenGtk/gtk-gui/generated.cs
@@ -6,9 +6,10 @@ namespace Stetic
 	{
 		private static bool initialized;
 
-		internal static void Initialize (Gtk.Widget iconRenderer)
+		internal static void Initialize(Gtk.Widget iconRenderer)
 		{
-			if ((Stetic.Gui.initialized == false)) {
+			if ((Stetic.Gui.initialized == false))
+			{
 				Stetic.Gui.initialized = true;
 			}
 		}
@@ -17,50 +18,55 @@ namespace Stetic
 	internal class BinContainer
 	{
 		private Gtk.Widget child;
-		
+
 		private Gtk.UIManager uimanager;
 
-		public static BinContainer Attach (Gtk.Bin bin)
+		public static BinContainer Attach(Gtk.Bin bin)
 		{
-			BinContainer bc = new BinContainer ();
-			bin.SizeRequested += new Gtk.SizeRequestedHandler (bc.OnSizeRequested);
-			bin.SizeAllocated += new Gtk.SizeAllocatedHandler (bc.OnSizeAllocated);
-			bin.Added += new Gtk.AddedHandler (bc.OnAdded);
+			BinContainer bc = new BinContainer();
+			bin.SizeRequested += new Gtk.SizeRequestedHandler(bc.OnSizeRequested);
+			bin.SizeAllocated += new Gtk.SizeAllocatedHandler(bc.OnSizeAllocated);
+			bin.Added += new Gtk.AddedHandler(bc.OnAdded);
 			return bc;
 		}
 
-		private void OnSizeRequested (object sender, Gtk.SizeRequestedArgs args)
+		private void OnSizeRequested(object sender, Gtk.SizeRequestedArgs args)
 		{
-			if ((this.child != null)) {
-				args.Requisition = this.child.SizeRequest ();
+			if ((this.child != null))
+			{
+				args.Requisition = this.child.SizeRequest();
 			}
 		}
 
-		private void OnSizeAllocated (object sender, Gtk.SizeAllocatedArgs args)
+		private void OnSizeAllocated(object sender, Gtk.SizeAllocatedArgs args)
 		{
-			if ((this.child != null)) {
+			if ((this.child != null))
+			{
 				this.child.Allocation = args.Allocation;
 			}
 		}
 
-		private void OnAdded (object sender, Gtk.AddedArgs args)
+		private void OnAdded(object sender, Gtk.AddedArgs args)
 		{
 			this.child = args.Widget;
 		}
 
-		public void SetUiManager (Gtk.UIManager uim)
+		public void SetUiManager(Gtk.UIManager uim)
 		{
 			this.uimanager = uim;
-			this.child.Realized += new System.EventHandler (this.OnRealized);
+			this.child.Realized += new System.EventHandler(this.OnRealized);
 		}
 
-		private void OnRealized (object sender, System.EventArgs args)
+		private void OnRealized(object sender, System.EventArgs args)
 		{
-			if ((this.uimanager != null)) {
+			if ((this.uimanager != null))
+			{
 				Gtk.Widget w;
 				w = this.child.Toplevel;
-				if (((w != null) && typeof(Gtk.Window).IsInstanceOfType (w))) {
-					((Gtk.Window)(w)).AddAccelGroup (this.uimanager.AccelGroup);
+				if (((w != null)
+							&& typeof(Gtk.Window).IsInstanceOfType(w)))
+				{
+					((Gtk.Window)(w)).AddAccelGroup(this.uimanager.AccelGroup);
 					this.uimanager = null;
 				}
 			}
@@ -69,12 +75,12 @@ namespace Stetic
 
 	internal class ActionGroups
 	{
-		public static Gtk.ActionGroup GetActionGroup (System.Type type)
+		public static Gtk.ActionGroup GetActionGroup(System.Type type)
 		{
-			return Stetic.ActionGroups.GetActionGroup (type.FullName);
+			return Stetic.ActionGroups.GetActionGroup(type.FullName);
 		}
 
-		public static Gtk.ActionGroup GetActionGroup (string name)
+		public static Gtk.ActionGroup GetActionGroup(string name)
 		{
 			return null;
 		}

--- a/ZoraGenGtk/gtk-gui/gui.stetic
+++ b/ZoraGenGtk/gtk-gui/gui.stetic
@@ -8,7 +8,7 @@
     <widget-library name="glade-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <widget-library name="../bin/Debug/ZoraGenGtk.exe" internal="true" />
   </import>
-  <widget class="Gtk.Window" id="Zyrenth.ZoraGen.GtkUI.MainWindow" design-size="444 258">
+  <widget class="Gtk.Window" id="Zyrenth.ZoraGen.GtkUI.MainWindow" design-size="513 284">
     <action-group name="Default">
       <action id="FileAction">
         <property name="Type">Action</property>
@@ -2881,7 +2881,7 @@ RigHtN ♥N  h</property>
       </widget>
     </child>
   </widget>
-  <widget class="Gtk.Dialog" id="Zyrenth.ZoraGen.GtkUI.ViewSecretsDialog" design-size="305 286">
+  <widget class="Gtk.Dialog" id="Zyrenth.ZoraGen.GtkUI.ViewSecretsDialog" design-size="444 311">
     <property name="MemberName" />
     <property name="Title" translatable="yes">Generate Secrets</property>
     <property name="Icon">resource:Zyrenth.ZoraGen.GtkUI.Farore.ico</property>
@@ -2980,20 +2980,245 @@ RigHtN ♥N  h</property>
               </packing>
             </child>
             <child>
+              <widget class="Gtk.Table" id="table2">
+                <property name="MemberName" />
+                <property name="NRows">11</property>
+                <property name="RowSpacing">1</property>
+                <property name="ColumnSpacing">6</property>
+                <child>
+                  <widget class="Gtk.Label" id="label5">
+                    <property name="MemberName" />
+                    <property name="LabelProp" translatable="yes">Secret
+(for Game1)</property>
+                    <property name="Justify">Center</property>
+                  </widget>
+                  <packing>
+                    <property name="AutoSize">False</property>
+                    <property name="XOptions">Fill</property>
+                    <property name="YOptions">Fill</property>
+                    <property name="XExpand">False</property>
+                    <property name="XFill">True</property>
+                    <property name="XShrink">False</property>
+                    <property name="YExpand">False</property>
+                    <property name="YFill">True</property>
+                    <property name="YShrink">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="Zyrenth.ZoraGen.GtkUI.SmallSecretWidget" id="swSec1">
+                    <property name="MemberName" />
+                    <property name="Events">ButtonPressMask</property>
+                  </widget>
+                  <packing>
+                    <property name="TopAttach">1</property>
+                    <property name="BottomAttach">2</property>
+                    <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
+                    <property name="YOptions">Fill</property>
+                    <property name="XExpand">False</property>
+                    <property name="XFill">True</property>
+                    <property name="XShrink">False</property>
+                    <property name="YExpand">False</property>
+                    <property name="YFill">True</property>
+                    <property name="YShrink">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="Zyrenth.ZoraGen.GtkUI.SmallSecretWidget" id="swSec10">
+                    <property name="MemberName" />
+                    <property name="Events">ButtonPressMask</property>
+                  </widget>
+                  <packing>
+                    <property name="TopAttach">10</property>
+                    <property name="BottomAttach">11</property>
+                    <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
+                    <property name="YOptions">Fill</property>
+                    <property name="XExpand">False</property>
+                    <property name="XFill">True</property>
+                    <property name="XShrink">False</property>
+                    <property name="YExpand">False</property>
+                    <property name="YFill">True</property>
+                    <property name="YShrink">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="Zyrenth.ZoraGen.GtkUI.SmallSecretWidget" id="swSec2">
+                    <property name="MemberName" />
+                    <property name="Events">ButtonPressMask</property>
+                  </widget>
+                  <packing>
+                    <property name="TopAttach">2</property>
+                    <property name="BottomAttach">3</property>
+                    <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
+                    <property name="YOptions">Fill</property>
+                    <property name="XExpand">False</property>
+                    <property name="XFill">True</property>
+                    <property name="XShrink">False</property>
+                    <property name="YExpand">False</property>
+                    <property name="YFill">True</property>
+                    <property name="YShrink">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="Zyrenth.ZoraGen.GtkUI.SmallSecretWidget" id="swSec3">
+                    <property name="MemberName" />
+                    <property name="Events">ButtonPressMask</property>
+                  </widget>
+                  <packing>
+                    <property name="TopAttach">3</property>
+                    <property name="BottomAttach">4</property>
+                    <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
+                    <property name="YOptions">Fill</property>
+                    <property name="XExpand">False</property>
+                    <property name="XFill">True</property>
+                    <property name="XShrink">False</property>
+                    <property name="YExpand">False</property>
+                    <property name="YFill">True</property>
+                    <property name="YShrink">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="Zyrenth.ZoraGen.GtkUI.SmallSecretWidget" id="swSec4">
+                    <property name="MemberName" />
+                    <property name="Events">ButtonPressMask</property>
+                  </widget>
+                  <packing>
+                    <property name="TopAttach">4</property>
+                    <property name="BottomAttach">5</property>
+                    <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
+                    <property name="YOptions">Fill</property>
+                    <property name="XExpand">False</property>
+                    <property name="XFill">True</property>
+                    <property name="XShrink">False</property>
+                    <property name="YExpand">False</property>
+                    <property name="YFill">True</property>
+                    <property name="YShrink">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="Zyrenth.ZoraGen.GtkUI.SmallSecretWidget" id="swSec5">
+                    <property name="MemberName" />
+                    <property name="Events">ButtonPressMask</property>
+                  </widget>
+                  <packing>
+                    <property name="TopAttach">5</property>
+                    <property name="BottomAttach">6</property>
+                    <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
+                    <property name="YOptions">Fill</property>
+                    <property name="XExpand">False</property>
+                    <property name="XFill">True</property>
+                    <property name="XShrink">False</property>
+                    <property name="YExpand">False</property>
+                    <property name="YFill">True</property>
+                    <property name="YShrink">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="Zyrenth.ZoraGen.GtkUI.SmallSecretWidget" id="swSec6">
+                    <property name="MemberName" />
+                    <property name="Events">ButtonPressMask</property>
+                  </widget>
+                  <packing>
+                    <property name="TopAttach">6</property>
+                    <property name="BottomAttach">7</property>
+                    <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
+                    <property name="YOptions">Fill</property>
+                    <property name="XExpand">False</property>
+                    <property name="XFill">True</property>
+                    <property name="XShrink">False</property>
+                    <property name="YExpand">False</property>
+                    <property name="YFill">True</property>
+                    <property name="YShrink">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="Zyrenth.ZoraGen.GtkUI.SmallSecretWidget" id="swSec7">
+                    <property name="MemberName" />
+                    <property name="Events">ButtonPressMask</property>
+                  </widget>
+                  <packing>
+                    <property name="TopAttach">7</property>
+                    <property name="BottomAttach">8</property>
+                    <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
+                    <property name="YOptions">Fill</property>
+                    <property name="XExpand">False</property>
+                    <property name="XFill">True</property>
+                    <property name="XShrink">False</property>
+                    <property name="YExpand">False</property>
+                    <property name="YFill">True</property>
+                    <property name="YShrink">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="Zyrenth.ZoraGen.GtkUI.SmallSecretWidget" id="swSec8">
+                    <property name="MemberName" />
+                    <property name="Events">ButtonPressMask</property>
+                  </widget>
+                  <packing>
+                    <property name="TopAttach">8</property>
+                    <property name="BottomAttach">9</property>
+                    <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
+                    <property name="YOptions">Fill</property>
+                    <property name="XExpand">False</property>
+                    <property name="XFill">True</property>
+                    <property name="XShrink">False</property>
+                    <property name="YExpand">False</property>
+                    <property name="YFill">True</property>
+                    <property name="YShrink">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="Zyrenth.ZoraGen.GtkUI.SmallSecretWidget" id="swSec9">
+                    <property name="MemberName" />
+                    <property name="Events">ButtonPressMask</property>
+                  </widget>
+                  <packing>
+                    <property name="TopAttach">9</property>
+                    <property name="BottomAttach">10</property>
+                    <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
+                    <property name="YOptions">Fill</property>
+                    <property name="XExpand">False</property>
+                    <property name="XFill">True</property>
+                    <property name="XShrink">False</property>
+                    <property name="YExpand">False</property>
+                    <property name="YFill">True</property>
+                    <property name="YShrink">False</property>
+                  </packing>
+                </child>
+              </widget>
+              <packing>
+                <property name="Position">1</property>
+                <property name="AutoSize">False</property>
+                <property name="Expand">False</property>
+                <property name="Fill">False</property>
+                <property name="Padding">6</property>
+              </packing>
+            </child>
+            <child>
               <widget class="Gtk.Table" id="table1">
                 <property name="MemberName" />
                 <property name="NRows">11</property>
                 <property name="NColumns">2</property>
                 <property name="RowSpacing">1</property>
-                <property name="ColumnSpacing">6</property>
+                <property name="ColumnSpacing">8</property>
                 <child>
                   <placeholder />
                 </child>
                 <child>
                   <widget class="Gtk.Label" id="label3">
                     <property name="MemberName" />
-                    <property name="Xalign">0</property>
-                    <property name="LabelProp" translatable="yes">Memories:</property>
+                    <property name="LabelProp" translatable="yes">Memories
+(for Game2)</property>
+                    <property name="Justify">Center</property>
                   </widget>
                   <packing>
                     <property name="AutoSize">True</property>
@@ -3055,7 +3280,7 @@ RigHtN ♥N  h</property>
                   <widget class="Gtk.Label" id="lblMem2">
                     <property name="MemberName" />
                     <property name="Xalign">0</property>
-                    <property name="LabelProp" translatable="yes">label2</property>
+                    <property name="LabelProp" translatable="yes" />
                   </widget>
                   <packing>
                     <property name="TopAttach">2</property>
@@ -3419,7 +3644,7 @@ RigHtN ♥N  h</property>
                 </child>
               </widget>
               <packing>
-                <property name="Position">1</property>
+                <property name="Position">2</property>
                 <property name="AutoSize">True</property>
                 <property name="Expand">False</property>
                 <property name="Fill">False</property>

--- a/ZoraGenGtk/gtk-gui/gui.stetic
+++ b/ZoraGenGtk/gtk-gui/gui.stetic
@@ -692,6 +692,7 @@ Moosh</property>
                         <property name="Type">TextOnly</property>
                         <property name="Label" translatable="yes">All Rings</property>
                         <property name="UseUnderline">True</property>
+                        <signal name="Clicked" handler="OnBtnAllRingsClicked" />
                       </widget>
                       <packing>
                         <property name="Position">0</property>
@@ -707,6 +708,7 @@ Moosh</property>
                         <property name="Type">TextOnly</property>
                         <property name="Label" translatable="yes">None</property>
                         <property name="UseUnderline">True</property>
+                        <signal name="Clicked" handler="OnBtnNoRingsClicked" />
                       </widget>
                       <packing>
                         <property name="Position">1</property>
@@ -3280,7 +3282,6 @@ RigHtN ♥N  h</property>
                   <widget class="Gtk.Label" id="lblMem2">
                     <property name="MemberName" />
                     <property name="Xalign">0</property>
-                    <property name="LabelProp" translatable="yes" />
                   </widget>
                   <packing>
                     <property name="TopAttach">2</property>


### PR DESCRIPTION
This displays both sets of secrets when you click "generate secrets" - not just return secrets - so now you can get the item in the unlinked game as well, without needing to find that secret from the linked game.

It may also interest you to know that any secret created with GameID 0 is a "universal" secret - it works on any file... I'm documenting them here: http://wiki.zeldahacking.net/oracle/Universal_secrets